### PR TITLE
Added the landing page message for the new site.

### DIFF
--- a/docs/next/modules/en/nav.adoc
+++ b/docs/next/modules/en/nav.adoc
@@ -1,5 +1,4 @@
-* xref:README.adoc[SUSE Observability docs!]
-* xref:classic.adoc[Docs for all SUSE Observability products]
+* xref:classic.adoc[SUSE Observability documentation]
 * Get started
 ** xref:k8s-quick-start-guide.adoc[Quick start guide]
 ** xref:k8s-getting-started.adoc[SUSE Observability walk-through]

--- a/docs/next/modules/en/pages/README.adoc
+++ b/docs/next/modules/en/pages/README.adoc
@@ -10,8 +10,8 @@ Visit the xref:/k8s-suse-rancher-prime.adoc[Rancher Prime getting started guide]
 == Can't find something?
 
 *Search for it!* Use the search bar on the top right.
-If you believe any documentation is missing, please let us know on the http://support.stackstate.com/[SUSE Observability support site].
+If you believe any documentation is missing, please let us know on the https://scc.suse.com/[SUSE Observability support site].
 
 == Troubleshooting and support
 
-Any questions? We love to help! Find our support team on the http://support.stackstate.com/[SUSE Observability support site].
+Any questions? We love to help! Find our support team on the https://scc.suse.com/[SUSE Observability support site].

--- a/docs/next/modules/en/pages/classic.adoc
+++ b/docs/next/modules/en/pages/classic.adoc
@@ -1,8 +1,12 @@
-= Welcome to the SUSE Observability docs!
+= Welcome to the new home of SUSE Observability docs!
 :cover: .gitbook/assets/gitbook-cover.jpg
 :coverY: 0
 
+You are now viewing the updated version of our documentation. 
+
 Select your version of SUSE Observability to jump to the associated documentation.
+
+To refer to older versions of the documentation, use the https://archivedocs.stackstate.com[archive].
 
 [discrete]
 === SUSE Observability

--- a/docs/next/modules/en/pages/classic.adoc
+++ b/docs/next/modules/en/pages/classic.adoc
@@ -2,9 +2,7 @@
 :cover: .gitbook/assets/gitbook-cover.jpg
 :coverY: 0
 
-You are now viewing the updated version of our documentation. 
-
-Select your version of SUSE Observability to jump to the associated documentation.
+You are viewing the latest version of our documentation. Select topics from the content menu on the left. 
 
 To refer to older versions of the documentation, use the https://archivedocs.stackstate.com[archive].
 

--- a/docs/next/modules/en/pages/classic.adoc
+++ b/docs/next/modules/en/pages/classic.adoc
@@ -7,39 +7,22 @@ You are viewing the latest version of our documentation. Select topics from the 
 To refer to older versions of the documentation, use the https://archivedocs.stackstate.com[archive].
 
 [discrete]
-=== SUSE Observability
+=== SUSE Observability Kubernetes Troubleshooting (v6.0)
 
-Use SUSE Observability to troubleshoot your Rancher Kubernetes cluster.
+Use SUSE Observability to troubleshoot your Kubernetes cluster.
 
-🚀 https://docs.stackstate.com/[SUSE Observability docs]
-
-[discrete]
-=== StackState Kubernetes Troubleshooting (v6.0)
-
-Use StackState to troubleshoot your Kubernetes cluster.
-
-🚀 https://docs.stackstate.com/v/6.0[SUSE Observability docs]
+xref:./README.adoc[SUSE Observability docs]
 
 [discrete]
-=== StackState Self-hosted
+=== SUSE Observability Self-hosted
 
-Use StackState Self-hosted to observe an extensive set of technologies that originate either in your own data centers or in the cloud.
+Use SUSE Observability Self-hosted to observe an extensive set of technologies that originate either in your own data centers or in the cloud.
 
-↗️ *https://docs.stackstate.com/v/5.1/latest[StackState Self-hosted v5.1 docs] - latest self-hosted release!*
-
-↗️ https://docs.stackstate.com/v/5.0/[StackState Self-hosted v5.0 docs]
-
-↗️ https://docs.stackstate.com/v/4.6/[StackState Self-hosted v4.6 docs]
+xref:/setup/install-stackstate/requirements.adoc[SUSE Observability Self-hosted] - *latest self-hosted release!*
 
 [discrete]
-=== StackState SaaS
+=== SUSE Observability SaaS
 
-Use StackState SaaS to observe cloud technologies, such as Kubernetes and AWS services.
+Use SUSE Observability SaaS to observe cloud technologies, such as Kubernetes and AWS services.
 
-↗️ https://docs.stackstate.com/v/stackstate-saas/[StackState SaaS docs]
-
-[TIP]
-====
-🔒 SUSE Observability is SOC2/3 certified. https://www.stackstate.com/compliance[Learn more]
-====
-
+xref:/saas/user-management.adoc[SUSE Observability SaaS docs]

--- a/docs/next/modules/en/pages/classic.adoc
+++ b/docs/next/modules/en/pages/classic.adoc
@@ -1,28 +1,39 @@
-= Welcome to the new home of SUSE Observability docs!
-:cover: .gitbook/assets/gitbook-cover.jpg
-:coverY: 0
+= SUSE Observability documentation
 
-You are viewing the latest version of our documentation. Select topics from the content menu on the left. 
+This the latest SUSE Observability documentation. Select topics from the content menu on the left.
 
-To refer to older versions of the documentation, use the https://archivedocs.stackstate.com[archive].
+For older versions of the documentation, use the https://archivedocs.stackstate.com[archive].
 
-[discrete]
-=== SUSE Observability Kubernetes Troubleshooting (v6.0)
+== Get started
 
-Use SUSE Observability to troubleshoot your Kubernetes cluster.
+Visit the xref:/k8s-suse-rancher-prime.adoc[Rancher Prime getting started
+guide] if you're a Rancher Prime user, if you're a SaaS user visit the
+xref:/k8s-quick-start-guide.adoc[quick start guide], if you are running SUSE
+Cloud Observability on AWS check the
+xref:/suse-cloud-observability-quick-start-guide.adoc[SUSE Cloud Observability
+quick start guide].
 
-xref:./README.adoc[SUSE Observability docs]
+== Can't find something?
 
-[discrete]
-=== SUSE Observability Self-hosted
+Use the search bar on the top right. If you think any documentation is
+missing, let us know on the https://scc.suse.com/[SUSE Observability
+support site].
 
-Use SUSE Observability Self-hosted to observe an extensive set of technologies that originate either in your own data centers or in the cloud.
+== Troubleshooting and support
 
-xref:/setup/install-stackstate/requirements.adoc[SUSE Observability Self-hosted] - *latest self-hosted release!*
+Any questions? We can help. Find the support team on the
+https://scc.suse.com/[SUSE Observability support site].
 
-[discrete]
-=== SUSE Observability SaaS
+== SUSE Observability Self-hosted
 
-Use SUSE Observability SaaS to observe cloud technologies, such as Kubernetes and AWS services.
+Use SUSE Observability Self-hosted to observe an extensive set of technologies
+from own data centers or the cloud.
+
+xref:/setup/install-stackstate/requirements.adoc[SUSE Observability Self-hosted]
+
+== SUSE Observability SaaS
+
+Use SUSE Observability SaaS to observe cloud technologies, such as Kubernetes
+and AWS services.
 
 xref:/saas/user-management.adoc[SUSE Observability SaaS docs]

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,9 +1,10 @@
 {
-  "name": "stackstate-product-docs",
+  "name": "F-stackstate-product-docs",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
+      "name": "F-stackstate-product-docs",
       "dependencies": {
         "@antora/lunr-extension": "^1.0.0-alpha.8",
         "@sntke/antora-mermaid-extension": "^0.0.6"
@@ -431,17 +432,6 @@
         "node": ">=8.11"
       }
     },
-    "node_modules/asciidoctor-opal-runtime/node_modules/brace-expansion": {
-      "version": "1.1.11",
-      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.11.tgz",
-      "integrity": "sha512-iCuPHDFgrHX7H2vEI/5xpz07zSHB00TpugqhmYtVmMO6518mCuRMoOYFldEBl0g187ufozdaHgWKcYFb61qGiA==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "balanced-match": "^1.0.0",
-        "concat-map": "0.0.1"
-      }
-    },
     "node_modules/asciidoctor-opal-runtime/node_modules/glob": {
       "version": "7.1.3",
       "resolved": "https://registry.npmjs.org/glob/-/glob-7.1.3.tgz",
@@ -549,6 +539,17 @@
       "resolved": "https://registry.npmjs.org/boolbase/-/boolbase-1.0.0.tgz",
       "integrity": "sha512-JZOSA7Mo9sNGB8+UjSgzdLtokWAky1zbztM3WRLCbZ70/3cTANmQmOdR7y2g+J0e2WXywy1yS468tY+IruqEww==",
       "license": "ISC"
+    },
+    "node_modules/brace-expansion": {
+      "version": "1.1.12",
+      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.12.tgz",
+      "integrity": "sha512-9T9UjW3r0UW5c1Q7GTwllptXwhvYmEzFhzMfZ9H7FQWt+uZePjZPjBP/W1ZEyZ1twGWom5/56TF4lPcqjnDHcg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "balanced-match": "^1.0.0",
+        "concat-map": "0.0.1"
+      }
     },
     "node_modules/braces": {
       "version": "3.0.3",

--- a/ss-local-playbook.yml
+++ b/ss-local-playbook.yml
@@ -1,6 +1,6 @@
 site:
   title: 'SUSE® Rancher Prime: Observability'
-  start_page: next@suse-observability:en:README.adoc
+  start_page: next@suse-observability:en:classic.adoc
 
 content:
   sources:

--- a/ss-remote-playbook.yml
+++ b/ss-remote-playbook.yml
@@ -1,6 +1,6 @@
 site:
   title: 'SUSE® Rancher Prime: Observability'
-  start_page: next@suse-observability:en:README.adoc
+  start_page: next@suse-observability:en:classic.adoc
 
 content:
   sources:


### PR DESCRIPTION
This chnage merges and simplifies the two landing pages 'classic' and 'readme'. This makes sense as this is now just the SUSE Observability product docs for Rancher Prime and not the other StackState products.