### PR TITLE
doc: add supported architectures for the agent

### DIFF
--- a/docs/next/modules/en/nav.adoc
+++ b/docs/next/modules/en/nav.adoc
@@ -73,6 +73,7 @@
 *** xref:setup/agent/k8s-custom-secrets-setup-deprecated.adoc[Custom Secret Management (Deprecated)]
 ** xref:setup/agent/k8sTs-agent-request-tracing.adoc[Request tracing]
 *** xref:setup/agent/k8sTs-agent-request-tracing-certificates.adoc[Certificates for sidecar injection]
+** xref:setup/agent/supported-architectures.adoc[Supported architectures]
 * Open Telemetry
 ** xref:setup/otel/overview.adoc[Overview]
 ** xref:setup/otel/getting-started/README.adoc[Getting started]

--- a/docs/next/modules/en/pages/setup/agent/supported-architectures.adoc
+++ b/docs/next/modules/en/pages/setup/agent/supported-architectures.adoc
@@ -1,9 +1,8 @@
 = SUSE Observability Agent supported architectures
 
-Please note that SUSE Observability is designed and tested to run on specific hardware architectures. Installation and operation are exclusively supported on systems utilizing one of the following processor architectures:
+SUSE Observability is designed and tested to run on specific hardware architectures. Installation and operation are supported on these systems:
 
 * `x86_64` (also known as AMD64 or Intel 64)
 * `arm64` (also known as AArch64)
 
-Ensure your target environment meets these requirements before proceeding with the deployment. Attempting to install or run SUSE Observability on any other architecture is not supported and will result in failure.
-
+Ensure your target environment meets these requirements before proceeding with a deployment. Installing or running SUSE Observability on other architectures is not supported.

--- a/docs/next/modules/en/pages/setup/agent/supported-architectures.adoc
+++ b/docs/next/modules/en/pages/setup/agent/supported-architectures.adoc
@@ -1,0 +1,9 @@
+= SUSE Observability Agent supported architectures
+
+Please note that SUSE Observability is designed and tested to run on specific hardware architectures. Installation and operation are exclusively supported on systems utilizing one of the following processor architectures:
+
+* `x86_64` (also known as AMD64 or Intel 64)
+* `arm64` (also known as AArch64)
+
+Ensure your target environment meets these requirements before proceeding with the deployment. Attempting to install or run SUSE Observability on any other architecture is not supported and will result in failure.
+


### PR DESCRIPTION
As above, since we introduced ARM support in our agent builds we want to let the customers easily know which architectures are supported.