### PR TITLE
STAC-22196: Label ingestion api keys as deprecated and create content…

### DIFF
--- a/docs/next/modules/en/pages/use/security/k8s-ingestion-api-keys.adoc
+++ b/docs/next/modules/en/pages/use/security/k8s-ingestion-api-keys.adoc
@@ -1,7 +1,7 @@
 = API Keys
 :description: SUSE Observability
 
-API keys are used for sending telemetry data to SUSE Observability. It now offers two types of API keysasas:
+API keys are used for sending telemetry data to SUSE Observability. It now offers two types of API keys:
 
 * Receiver API Key: This key is typically generated during the initial installation of your SUSE Observability instance, and it never expires
 * Ingestion API Key: You can create Ingestion API Keys using the SUSE Observability CLI (STS). These keys offer expiration dates, requiring periodic rotation for continued functionality.

--- a/docs/next/modules/en/pages/use/security/k8s-ingestion-api-keys.adoc
+++ b/docs/next/modules/en/pages/use/security/k8s-ingestion-api-keys.adoc
@@ -1,7 +1,7 @@
 = API Keys
 :description: SUSE Observability
 
-API keys are used for sending telemetry data to SUSE Observability. It now offers two types of API keys:
+API keys are used for sending telemetry data to SUSE Observability. It now offers two types of API keysasas:
 
 * Receiver API Key: This key is typically generated during the initial installation of your SUSE Observability instance, and it never expires
 * Ingestion API Key: You can create Ingestion API Keys using the SUSE Observability CLI (STS). These keys offer expiration dates, requiring periodic rotation for continued functionality.
@@ -13,123 +13,8 @@ The receiver API key can be found in your `values.yaml` as the `receiverApiKey`,
 . Open one of the installed instances
 . Scroll down to the first set of installation instructions. It shows the API key as `STACKSTATE_RECEIVER_API_KEY` in text and as `'stackstate.apiKey'` in the command.
 
-== Ingestion API Keys
+== Ingestion API Keys (`Deprecated`)
 
-Ingestion API Keys are used by external tools to ingest data (like metrics, events, traces and so on) to the SUSE Observability cluster.
-These tools can be STS Agent or/and OTel Collector.
+Ingestion API Keys were used by external tools to ingest data (such as metrics, events and traces) to the SUSE Observability cluster.
+These tools include the STS Agent or/and OTel Collector. Currently, the recommended authentication mechanism is through xref:/use/security/k8s-service-tokens.adoc#_authenticate_using_service_tokens_for_data_ingestion[Service Tokens].
 
-== Manage Ingestion API Keys
-
-Keys can be managed via the `sts` CLI. The following commands are available:
-
-[,sh]
-----
-> sts ingestion-api-key --help
-Manage API Keys used by ingestion pipelines, means data (spans, metrics, logs an so on) send by STS Agent, OTel and so on.
-
-Usage:
-  sts ingestion-api-key [command]
-
-Available Commands:
-  create      Create a new Ingestion Api Key
-  delete      Delete an Ingestion Api Key
-  list        List Ingestion Api Keys
-
-Use "sts ingestion-api-key [command] --help" for more information about a command.
-----
-
-=== Create Ingestion API Keys
-
-To create a Key in your instance of SUSE Observability, you can use the `sts` CLI.
-
-[,sh]
-----
-> sts ingestion-api-key create --name {NAME}
-----
-
-[NOTE]
-====
-Note that the Key will only be displayed once. It isn't possible to see the token again.
-====
-
-
-This command takes the following command line arguments:
-
-|===
-| Flag | Description
-
-| `--name`
-| The name of the Key.
-
-| `--description`
-| Optional description of the API Key.
-
-| `--expiration`
-| The expiration date of the Key, the format is yyyy-MM-dd. The expiration is optional.
-|===
-
-For example, the command below will create a Key with the name `my-ingestion-api-key`:
-
-[,sh]
-----
-> sts ingestion-api-key create --name my-ingestion-api-key
-✅ Ingestion API Key generated: iapikeyok-aaaaa-bbbb-ccccc-ddddd
-----
-
-=== List Ingestion API Keys
-
-The ID, name, expiration date and description of all created Ingestion API Keys can be seen using the `sts` CLI. For example:
-
-[,bash]
-----
-> sts ingestion-api-key list
-ID              | NAME                 | EXPIRATION | DESCRIPTION
-250558013078953 | my-ingestion-api-key |            | -
-----
-
-=== Delete Ingestion API Keys
-
-An Ingestion API Key can be deleted using the `sts` CLI. Pass the ID of the Key as an argument. For example:
-
-[,sh]
-----
-> sts ingestion-api-key delete  --id 250558013078953
-✅ Ingestion Api Key deleted: 250558013078953
-----
-
-== Authenticate using Ingestion API keys
-
-Once created, an Ingestion API Key can be used to authenticate:
-
-* suse-observability-agent
-* OTel Collector
-
-=== suse-observability-agent
-
-The SUSE Observability agent requires an API key for communication, historically known as the Receiver API Key. SUSE Observability now offers two options for authentication:
-
-* Receiver API Key: This key is typically generated during the initial installation of your SUSE Observability instance,
-* Ingestion API Key: You can create Ingestion API Keys using the SUSE Observability CLI (STS). These keys offer expiration dates, requiring periodic rotation for continued functionality.
-
-=== OTel Collector
-
-When using the SUSE Observability collector, you'll need to include an `Authorization` header in your configuration. The collector accepts either a Receiver API Key or an Ingestion API Key for authentication.
-The following code snippet provides an example configuration:
-
-[,yaml]
-----
-extensions:
-  bearertokenauth:
-    scheme: SUSE Observability
-    token: "${env:API_KEY}"
-exporters:
-  otlp/suse-observability:
-    auth:
-      authenticator: bearertokenauth
-    endpoint: <otlp-suse-observability-endpoint>:443
-  # or
-  otlphttp/suse-observability:
-    auth:
-      authenticator: bearertokenauth
-    endpoint: https://<otlp-http-suse-observability-endpoint>
-----

--- a/docs/next/modules/en/pages/use/security/k8s-service-tokens.adoc
+++ b/docs/next/modules/en/pages/use/security/k8s-service-tokens.adoc
@@ -114,3 +114,60 @@ To use a service token to talk directly to the SUSE Observability API, add it to
 ----
   > curl -X GET -H "X-API-Key: <TOKEN>" http://<tenant>.app.stackstate.io/api/server/status
 ----
+
+
+== Authenticate using Service Tokens for Data Ingestion
+
+In order to create a Service Token for data ingestion you need first to create a dedicated role for this purpose:
+[,sh]
+----
+> sts rbac create-subject --subject my-agent
+✅ Created subject 'my-agent'
+> sts rbac grant --subject my-agent --permission update-metrics
+✅ Granted permission 'update-metrics' on 'system' to subject 'my-agent'
+PERMISSION   | RESOURCE
+update-metrics | system
+----
+
+This will create a new role in SUSE Observability called `my-agent` and grant it the `update-metrics` permission. You can then create a ServiceToken for this role:
+
+[,sh]
+----
+> sts service-token create --name my-agent --roles my-agent
+✅ Service token created: svctok-XXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXX
+----
+
+The newly created service token can be used to authenticate:
+
+* suse-observability-agent
+* OTel Collector
+
+=== suse-observability-agent
+
+The SUSE Observability agent requires an API key for communication, historically known as the Receiver API Key. SUSE Observability now offers two options for authentication:
+
+* Receiver API Key: This key is typically generated during the initial installation of your SUSE Observability instance,
+* Service Token: You can create a Service Token using the SUSE Observability CLI (STS). These keys offer expiration dates, requiring periodic rotation for continued functionality.
+
+=== OTel Collector
+
+When using the SUSE Observability collector, you'll need to include an `Authorization` header in your configuration. The collector accepts either a Receiver API Key or a Service Token for authentication.
+The following code snippet provides an example configuration:
+
+[,yaml]
+----
+extensions:
+  bearertokenauth:
+    scheme: SUSE Observability
+    token: "${env:API_KEY}"
+exporters:
+  otlp/suse-observability:
+    auth:
+      authenticator: bearertokenauth
+    endpoint: <otlp-suse-observability-endpoint>:443
+  # or
+  otlphttp/suse-observability:
+    auth:
+      authenticator: bearertokenauth
+    endpoint: https://<otlp-http-suse-observability-endpoint>
+----


### PR DESCRIPTION
… for Service Tokens regarding their usage for data ingestion