### PR TITLE
Corrected refs for prerequisites

### DIFF
--- a/docs/latest/modules/en/pages/k8s-quick-start-guide.adoc
+++ b/docs/latest/modules/en/pages/k8s-quick-start-guide.adoc
@@ -386,7 +386,7 @@ To set up a SUSE Observability Google GKE integration you need to have:
 
 [CAUTION]
 ====
-Before you begin, check the <<_prerequisites_for_amazon_eks,prerequisites for Kubernetes>>.
+Before you begin, check the <<_prerequisites_for_google_gke,prerequisites for Kubernetes>>.
 ====
 
 
@@ -472,7 +472,7 @@ To set up a SUSE Observability Azure AKS integration you need to have:
 
 [CAUTION]
 ====
-Before you begin, check the <<_prerequisites_for_amazon_eks,prerequisites for Kubernetes>>.
+Before you begin, check the <<_prerequisites_for_azure_aks,prerequisites for Kubernetes>>.
 ====
 
 
@@ -546,7 +546,7 @@ To set up a SUSE Observability KOPS integration you need to have:
 
 [CAUTION]
 ====
-Before you begin, check the <<_prerequisites_for_amazon_eks,prerequisites for Kubernetes>>.
+Before you begin, check the <<_prerequisites_for_kops,prerequisites for Kubernetes>>.
 ====
 
 
@@ -622,7 +622,7 @@ To set up a SUSE Observability Self-hosted integration you need to have:
 
 [CAUTION]
 ====
-Before you begin, check the <<_prerequisites_for_amazon_eks,prerequisites for Kubernetes>>.
+Before you begin, check the <<_prerequisites_for_self_hosted,prerequisites for Kubernetes>>.
 ====
 
 


### PR DESCRIPTION
Most of the links for Kubernetes prerequisites are incorrectly pointing to Amazon EKS prerequisites.
Not sure how the references work on your backend, but updated them here to reflect the section that they're in.