### PR TITLE
fix typo in sts example

### DIFF
--- a/docs/latest/modules/en/pages/setup/security/rbac/rbac_permissions.adoc
+++ b/docs/latest/modules/en/pages/setup/security/rbac/rbac_permissions.adoc
@@ -158,7 +158,7 @@ List all subjects:
 
 [,text]
 ----
-sts rbac describe subjects
+sts rbac describe-subjects
 
 SUBJECT                                    | SOURCE
 stackstate-admin                           | Static


### PR DESCRIPTION
`sts rbac describe subjects` is incorrect syntax.