### PR TITLE
STAC-23528 Restoring clickhouse backup will not fail with

### DIFF
--- a/docs/latest/modules/en/pages/setup/data-management/backup_restore/kubernetes_backup.adoc
+++ b/docs/latest/modules/en/pages/setup/data-management/backup_restore/kubernetes_backup.adoc
@@ -587,7 +587,7 @@ where is printed:
 
 [CAUTION]
 ====
-*Restore functionality always overwrites data, all tables in the `otel` database will be dropped and restored from the backup. You must be careful to avoid the unexpected loss of existing data.*
+*Restore functionality overwrites the data. All tables in the `otel` database are dropped and restored from the backup. Beware to avoid unexpected data loss.*
 ====
 
 


### PR DESCRIPTION
"can't create table" erros anymore. A new version of the Clickhouse backup tool fixed this problem.