### PR TITLE
Update revdate so SU notices.

### DIFF
--- a/docs/latest/modules/en/pages/configure/health/send-health-data/repeat_snapshots.adoc
+++ b/docs/latest/modules/en/pages/configure/health/send-health-data/repeat_snapshots.adoc
@@ -1,5 +1,5 @@
 = Repeat Snapshots
-:revdate: 2025-07-10
+:revdate: 2025-10-27
 :page-revdate: {revdate}
 :description: SUSE Observability
 

--- a/docs/latest/modules/en/pages/configure/health/send-health-data/repeat_states.adoc
+++ b/docs/latest/modules/en/pages/configure/health/send-health-data/repeat_states.adoc
@@ -1,5 +1,5 @@
 = Repeat States
-:revdate: 2025-07-10
+:revdate: 2025-10-27
 :page-revdate: {revdate}
 :description: SUSE Observability
 

--- a/docs/latest/modules/en/pages/configure/health/send-health-data/transactional_increments.adoc
+++ b/docs/latest/modules/en/pages/configure/health/send-health-data/transactional_increments.adoc
@@ -1,5 +1,5 @@
 = Transactional Elements
-:revdate: 2025-07-10
+:revdate: 2025-10-27
 :page-revdate: {revdate}
 :description: SUSE Observability
 

--- a/docs/latest/modules/en/pages/setup/agent/k8s-custom-secrets-setup-deprecated.adoc
+++ b/docs/latest/modules/en/pages/setup/agent/k8s-custom-secrets-setup-deprecated.adoc
@@ -1,5 +1,5 @@
 = k8s Custom Secrets Setup (Deprecated)
-:revdate: 2025-07-10
+:revdate: 2025-10-27
 :page-revdate: {revdate}
 
 == Overview

--- a/docs/latest/modules/en/pages/setup/agent/k8s-custom-secrets-setup.adoc
+++ b/docs/latest/modules/en/pages/setup/agent/k8s-custom-secrets-setup.adoc
@@ -1,5 +1,5 @@
 = k8s Custom Secret Management
-:revdate: 2025-07-10
+:revdate: 2025-10-27
 :page-revdate: {revdate}
 
 == Overview


### PR DESCRIPTION
Update the revdate for those files that had heading levels changed to avoid untitled HTML docs occasionally occurring. Need a revdate bump as well, so that SU notices. Probably.