### PR TITLE
STAC-23425: note on access via port-forwarding

### DIFF
--- a/docs/latest/modules/en/pages/setup/install-stackstate/kubernetes_openshift/ingress.adoc
+++ b/docs/latest/modules/en/pages/setup/install-stackstate/kubernetes_openshift/ingress.adoc
@@ -38,7 +38,7 @@ ingress:
 
 What stands out in this file is the Nginx annotation to increase the allowed `proxy-body-size` to `50m` (larger than any expected request). By default, Nginx allows body sizes of maximum `1m`. SUSE Observability Agents and other data providers can sometimes send much larger requests. For this reason, you should make sure that the allowed body size is large enough, regardless of whether you are using Nginx or another ingress controller. Make sure to update the `baseUrl` in the values file generated during initial installation, it will be used by SUSE Observability to generate convenient installation instructions for the agent.
 
-The example uses the `ingressClassName` field to specify the https://kubernetes.io/docs/concepts/services-networking/ingress/#_ingress_class[ingress class] instead of the deprecated `kubernetes.io/ingress.class` annotation. If your cluster has a default ingress class defined the ingress class name field can be omitted.
+The example uses the `ingressClassName` field to specify the https://kubernetes.io/docs/concepts/services-networking/ingress/#_ingress_class[ingress class] instead of the deprecated `kubernetes.io/ingress.class` annotation. If your cluster has a default ingress class defined, the ingress class name field can be omitted.
 
 Include the `ingress_values.yaml` file when you run the `helm upgrade` command to deploy SUSE Observability:
 
@@ -103,7 +103,7 @@ opentelemetry-collector:
 
 What stands out in this file is the Nginx annotation to increase the allowed `proxy-body-size` to `50m` (larger than any expected request). By default, Nginx allows body sizes of maximum `1m`. SUSE Observability Agents and other data providers can sometimes send much larger requests. For this reason, you should make sure that the allowed body size is large enough, regardless of whether you are using Nginx or another ingress controller. Make sure to update the `baseUrl` in the values file generated during initial installation, it will be used by SUSE Observability to generate convenient installation instructions for the agent.
 
-The example uses the `ingressClassName` field to specify the https://kubernetes.io/docs/concepts/services-networking/ingress/#_ingress_class[ingress] instead of the deprecated `kubernetes.io/ingress.class` annotation. If your cluster has a default ingress class defined the ingress class name field can be omitted.
+The example uses the `ingressClassName` field to specify the https://kubernetes.io/docs/concepts/services-networking/ingress/#_ingress_class[ingress] instead of the deprecated `kubernetes.io/ingress.class` annotation. If your cluster has a default ingress class defined, the ingress class name field can be omitted.
 
 Include the `ingress_otel_values.yaml` file when you run the `helm upgrade` command to deploy SUSE Observability:
 

--- a/docs/latest/modules/en/pages/setup/install-stackstate/kubernetes_openshift/ingress.adoc
+++ b/docs/latest/modules/en/pages/setup/install-stackstate/kubernetes_openshift/ingress.adoc
@@ -38,7 +38,7 @@ ingress:
 
 What stands out in this file is the Nginx annotation to increase the allowed `proxy-body-size` to `50m` (larger than any expected request). By default, Nginx allows body sizes of maximum `1m`. SUSE Observability Agents and other data providers can sometimes send much larger requests. For this reason, you should make sure that the allowed body size is large enough, regardless of whether you are using Nginx or another ingress controller. Make sure to update the `baseUrl` in the values file generated during initial installation, it will be used by SUSE Observability to generate convenient installation instructions for the agent.
 
-The example uses the `ingressClassName` field to specify the https://kubernetes.io/docs/concepts/services-networking/ingress/#_ingress_class[ingress class] instead of the deprecated `kubernetes.io/ingress.class` annotation. If your cluster has a default ingress class defined the ingerss class name field can be omitted.
+The example uses the `ingressClassName` field to specify the https://kubernetes.io/docs/concepts/services-networking/ingress/#_ingress_class[ingress class] instead of the deprecated `kubernetes.io/ingress.class` annotation. If your cluster has a default ingress class defined the ingress class name field can be omitted.
 
 Include the `ingress_values.yaml` file when you run the `helm upgrade` command to deploy SUSE Observability:
 
@@ -56,7 +56,7 @@ suse-observability/suse-observability
 
 [NOTE]
 ====
-This step assummes that xref:/setup/install-stackstate/kubernetes_openshift/kubernetes_install.adoc#_generate_baseconfig_values.yaml_and_sizing_values.yaml[Generate `baseConfig_values.yaml` and `sizing_values.yaml`] was already executed.
+This step assumes that xref:/setup/install-stackstate/kubernetes_openshift/kubernetes_install.adoc#_generate_baseconfig_values.yaml_and_sizing_values.yaml[Generate `baseConfig_values.yaml` and `sizing_values.yaml`] was already executed.
 ====
 
 
@@ -103,7 +103,7 @@ opentelemetry-collector:
 
 What stands out in this file is the Nginx annotation to increase the allowed `proxy-body-size` to `50m` (larger than any expected request). By default, Nginx allows body sizes of maximum `1m`. SUSE Observability Agents and other data providers can sometimes send much larger requests. For this reason, you should make sure that the allowed body size is large enough, regardless of whether you are using Nginx or another ingress controller. Make sure to update the `baseUrl` in the values file generated during initial installation, it will be used by SUSE Observability to generate convenient installation instructions for the agent.
 
-The example uses the `ingressClassName` field to specify the https://kubernetes.io/docs/concepts/services-networking/ingress/#_ingress_class[ingress] instead of the deprecated `kubernetes.io/ingress.class` annotation. If your cluster has a default ingress class defined the ingerss class name field can be omitted.
+The example uses the `ingressClassName` field to specify the https://kubernetes.io/docs/concepts/services-networking/ingress/#_ingress_class[ingress] instead of the deprecated `kubernetes.io/ingress.class` annotation. If your cluster has a default ingress class defined the ingress class name field can be omitted.
 
 Include the `ingress_otel_values.yaml` file when you run the `helm upgrade` command to deploy SUSE Observability:
 
@@ -122,7 +122,7 @@ suse-observability/suse-observability
 
 [NOTE]
 ====
-This step assummes that xref:/setup/install-stackstate/kubernetes_openshift/kubernetes_install.adoc#_generate_baseconfig_values.yaml_and_sizing_values.yaml[Generate `baseConfig_values.yaml` and `sizing_values.yaml`] was already executed.
+This step assumes that xref:/setup/install-stackstate/kubernetes_openshift/kubernetes_install.adoc#_generate_baseconfig_values.yaml_and_sizing_values.yaml[Generate `baseConfig_values.yaml` and `sizing_values.yaml`] was already executed.
 ====
 
 

--- a/docs/latest/modules/en/pages/setup/install-stackstate/kubernetes_openshift/ingress.adoc
+++ b/docs/latest/modules/en/pages/setup/install-stackstate/kubernetes_openshift/ingress.adoc
@@ -59,7 +59,6 @@ suse-observability/suse-observability
 This step assumes that xref:/setup/install-stackstate/kubernetes_openshift/kubernetes_install.adoc#_generate_baseconfig_values.yaml_and_sizing_values.yaml[Generate `baseConfig_values.yaml` and `sizing_values.yaml`] was already executed.
 ====
 
-
 == Configure Ingress Rule for Open Telemetry
 
 The SUSE Observability Helm chart exposes an `opentelemetry-collector` service in its values where a dedicated `ingress` can be created. This is disabled by default. The ingress needed for `opentelemetry-collector` purposed needs to support GRPC protocol. The example below shows how to use the Helm chart to configure an nginx-ingress controller with GRPC and  TLS encryption enabled. Note that setting up the controller itself and the certificates is beyond the scope of this document.
@@ -154,6 +153,42 @@ SUSE Observability itself doesn't use TLS encrypted traffic, TLS encryption is e
 == Agents in the same cluster
 
 Agents that are deployed to the same cluster as SUSE Observability can of course use the external URL on which SUSE Observability is exposed, but it's also possible to configure the agent to directly connect to the SUSE Observability instance via the Kubernetes internal network only. To do that replace the value of the `'stackstate.url'` in the `helm install` command from the xref:/k8s-quick-start-guide.adoc[Agent Kubernetes installation] with the internal cluster URL for the router service (see also above): `http://<namespace>-suse-observability-router.<namespace>.svc.cluster.local:8080/receiver/stsAgent` (the `<namespace>` sections need to be replaced with the namespace of SUSE Observability).
+
+
+== Forwarding the {stackstate-product-name} router service port
+
+By default, the SUSE Observability Helm chart deploys a router pod and service. This service exposes port `8080`, which is the only entry point that needs to be exposed via Ingress.
+You can also access SUSE Observability via port-forwarding; when doing so, you must allow localhost as a request origin.
+
+To access the UI without configuring Ingress, forward the router service port:
+
+[,text]
+----
+kubectl port-forward service/<helm-release-name>-suse-observability-router 8080:8080 --namespace suse-observability
+----
+
+When accessing {stackstate-product-name} via port-forwarding, the browser uses `http://localhost:8080` as the request origin.
+To allow requests from this origin, add it to the `stackstate.allowedOrigins` list in the Helm values, or pass it directly to the Helm command::
+
+[,bash]
+----
+helm upgrade \
+  --install \
+  --namespace suse-observability \
+  --values $VALUES_DIR/suse-observability-values/templates/baseConfig_values.yaml \
+  --values $VALUES_DIR/suse-observability-values/templates/sizing_values.yaml \
+  --values $VALUES_DIR/suse-observability-values/templates/affinity_values.yaml \
+  --set stackstate.allowedOrigins={"http://localhost:8080"} \
+suse-observability \
+suse-observability/suse-observability
+----
+
+[WARNING]
+====
+* Allowing `localhost` in `stackstate.allowedOrigins` is intended only for local development or debugging when using port-forwarding.
+* This is *not* a production setup. Remove this allowed origin when exposing {stackstate-product-name} via Ingress.
+====
+
 
 == See also
 

--- a/docs/latest/modules/en/pages/setup/install-stackstate/kubernetes_openshift/ingress.adoc
+++ b/docs/latest/modules/en/pages/setup/install-stackstate/kubernetes_openshift/ingress.adoc
@@ -160,6 +160,12 @@ Agents that are deployed to the same cluster as SUSE Observability can of course
 By default, the SUSE Observability Helm chart deploys a router pod and service. This service exposes port `8080`, which is the only entry point that needs to be exposed via Ingress.
 You can also access SUSE Observability via port-forwarding; when doing so, you must allow localhost as a request origin.
 
+[WARNING]
+====
+* Allowing `localhost` in `stackstate.allowedOrigins` is intended only for local development or debugging when using port-forwarding.
+* This is *not* a production setup. Remove this allowed origin when exposing {stackstate-product-name} via Ingress.
+====
+
 To access the UI without configuring Ingress, forward the router service port:
 
 [,text]
@@ -182,12 +188,6 @@ helm upgrade \
 suse-observability \
 suse-observability/suse-observability
 ----
-
-[WARNING]
-====
-* Allowing `localhost` in `stackstate.allowedOrigins` is intended only for local development or debugging when using port-forwarding.
-* This is *not* a production setup. Remove this allowed origin when exposing {stackstate-product-name} via Ingress.
-====
 
 
 == See also

--- a/docs/latest/modules/en/pages/setup/install-stackstate/requirements.adoc
+++ b/docs/latest/modules/en/pages/setup/install-stackstate/requirements.adoc
@@ -152,8 +152,8 @@ By default, the SUSE Observability Helm chart will deploy a router pod and servi
 kubectl port-forward service/<helm-release-name>-stackstate-k8s-router 8080:8080 --namespace stackstate
 ----
 
-When accessing SUSE Observability via port-forwarding, the browser uses `http://localhost:8080` as the request origin.
-Since this origin is not allowed by default, UI requests (including WebSocket connections) may be rejected.
+When accessing {stackstate-product-name} via port-forwarding, the browser uses `http://localhost:8080` as the request origin.
+Since this origin is not allowed by default, UI requests (including WebSocket connections) will be rejected.
 
 You can fix this by adding `http://localhost:8080` to the `stackstate.allowedOrigins` list in the Helm values, or by passing it directly to the deployment command:
 
@@ -172,11 +172,11 @@ suse-observability/suse-observability
 
 [WARNING]
 ====
-Allowing `localhost` in `stackstate.allowedOrigins` is intended only for local development or debugging when using port-forwarding.
-This is *not* a production setup. Make sure to remove this allowed origin when exposing SUSE Observability via Ingress.
+* Allowing `localhost` in `stackstate.allowedOrigins` is intended only for local development or debugging when using port-forwarding.
+* This is *not* a production setup. Make sure to remove this allowed origin when exposing {stackstate-product-name} via Ingress.
 ====
 
-When configuring Ingress, make sure to allow for large request body sizes (50MB) that may be sent occasionally by data sources like the SUSE Observability Agent or the AWS integration.
+When configuring Ingress, ensure to allow large request body sizes (50MB) that may be sent occasionally by data sources like the {stackstate-product-name} Agent or the AWS integration.
 
 For more details on configuring Ingress, have a look at the page xref:/setup/install-stackstate/kubernetes_openshift/ingress.adoc[Configure Ingress docs].
 

--- a/docs/latest/modules/en/pages/setup/install-stackstate/requirements.adoc
+++ b/docs/latest/modules/en/pages/setup/install-stackstate/requirements.adoc
@@ -143,43 +143,6 @@ The storage estimates presented take into account a default of 14 days of retent
 
 For more details on the defaults used, see the page xref:/setup/install-stackstate/kubernetes_openshift/storage.adoc[Configure storage].
 
-=== Ingress
-
-By default, the SUSE Observability Helm chart will deploy a router pod and service. This service's port `8080` is the only entry point that needs to be exposed via Ingress. You can access SUSE Observability without configuring Ingress by forwarding this port:
-
-[,text]
-----
-kubectl port-forward service/<helm-release-name>-stackstate-k8s-router 8080:8080 --namespace stackstate
-----
-
-When accessing {stackstate-product-name} via port-forwarding, the browser uses `http://localhost:8080` as the request origin.
-Since this origin is not allowed by default, UI requests (including WebSocket connections) will be rejected.
-
-You can fix this by adding `http://localhost:8080` to the `stackstate.allowedOrigins` list in the Helm values, or by passing it directly to the deployment command:
-
-[,bash]
-----
-helm upgrade \
-  --install \
-  --namespace suse-observability \
-  --values $VALUES_DIR/suse-observability-values/templates/baseConfig_values.yaml \
-  --values $VALUES_DIR/suse-observability-values/templates/sizing_values.yaml \
-  --values $VALUES_DIR/suse-observability-values/templates/affinity_values.yaml \
-  --set stackstate.allowedOrigins={"http://localhost:8080"} \
-suse-observability \
-suse-observability/suse-observability
-----
-
-[WARNING]
-====
-* Allowing `localhost` in `stackstate.allowedOrigins` is intended only for local development or debugging when using port-forwarding.
-* This is *not* a production setup. Make sure to remove this allowed origin when exposing {stackstate-product-name} via Ingress.
-====
-
-When configuring Ingress, ensure to allow large request body sizes (50MB) that may be sent occasionally by data sources like the {stackstate-product-name} Agent or the AWS integration.
-
-For more details on configuring Ingress, have a look at the page xref:/setup/install-stackstate/kubernetes_openshift/ingress.adoc[Configure Ingress docs].
-
 === Namespace resource limits
 
 It isn't recommended to set a ResourceQuota as this can interfere with resource requests. The resources required by SUSE Observability will vary according to the features used, configured resource limits and dynamic usage patterns, such as Deployment or DaemonSet scaling.

--- a/docs/latest/modules/en/pages/setup/install-stackstate/requirements.adoc
+++ b/docs/latest/modules/en/pages/setup/install-stackstate/requirements.adoc
@@ -152,6 +152,22 @@ By default, the SUSE Observability Helm chart will deploy a router pod and servi
 kubectl port-forward service/<helm-release-name>-stackstate-k8s-router 8080:8080 --namespace stackstate
 ----
 
+When accessing SUSE Observability via port-forwarding, the browser uses `http://localhost:8080` as the request origin.
+Since this origin is not allowed by default, UI requests (including WebSocket connections) may be rejected.
+
+You can fix this by adding `http://localhost:8080` to the `stackstate.allowedOrigins` list in the Helm values, or by passing it directly to the deployment command:
+
+[,text]
+----
+--set stackstate.allowedOrigins={"http://localhost:8080"}
+----
+
+[WARNING]
+====
+Allowing `localhost` in `stackstate.allowedOrigins` is intended only for local development or debugging when using port-forwarding.
+This is *not* a production setup. Make sure to remove this allowed origin when exposing SUSE Observability via Ingress.
+====
+
 When configuring Ingress, make sure to allow for large request body sizes (50MB) that may be sent occasionally by data sources like the SUSE Observability Agent or the AWS integration.
 
 For more details on configuring Ingress, have a look at the page xref:/setup/install-stackstate/kubernetes_openshift/ingress.adoc[Configure Ingress docs].

--- a/docs/latest/modules/en/pages/setup/install-stackstate/requirements.adoc
+++ b/docs/latest/modules/en/pages/setup/install-stackstate/requirements.adoc
@@ -157,9 +157,17 @@ Since this origin is not allowed by default, UI requests (including WebSocket co
 
 You can fix this by adding `http://localhost:8080` to the `stackstate.allowedOrigins` list in the Helm values, or by passing it directly to the deployment command:
 
-[,text]
+[,bash]
 ----
---set stackstate.allowedOrigins={"http://localhost:8080"}
+helm upgrade \
+  --install \
+  --namespace suse-observability \
+  --values $VALUES_DIR/suse-observability-values/templates/baseConfig_values.yaml \
+  --values $VALUES_DIR/suse-observability-values/templates/sizing_values.yaml \
+  --values $VALUES_DIR/suse-observability-values/templates/affinity_values.yaml \
+  --set stackstate.allowedOrigins={"http://localhost:8080"} \
+suse-observability \
+suse-observability/suse-observability
 ----
 
 [WARNING]


### PR DESCRIPTION
By adding `http://localhost:8080` to the `stackstate.allowedOrigins` list, the app works as expected.

This has been captured as a note under the requirements / ingress section for setting up a SUSE Observability installation. 

Below a screenshot to show a working websocket connection and populated UI.
<img width="1649" height="1047" alt="Screenshot 2025-12-31 at 11 38 37" src="https://github.com/user-attachments/assets/d3376898-f0a1-4eb2-aac4-abe9286eddcc" />
