### PR TITLE
STAC-0: consolidate stackpack 2.0 feature flags

### DIFF
--- a/docs/latest/modules/de/pages/setup/custom-integrations/develop.adoc
+++ b/docs/latest/modules/de/pages/setup/custom-integrations/develop.adoc
@@ -7,7 +7,7 @@ ifdef::ss-ff-stackpacks2_enabled[]
 
 [IMPORTANT]
 ====
-Dieses Feature befindet sich in der Vorproduktion und ist nicht veröffentlicht. Es ist nur verfügbar, wenn die Umgebungsvariable `STS_EXPERIMENTAL_STACKPACK` gesetzt ist. Es können Breaking Changes auftreten.
+Dieses Feature befindet sich in der Vorproduktion und ist nicht veröffentlicht. Es ist nur verfügbar, wenn die Umgebungsvariable `STS_EXPERIMENTAL_STACKPACKS` gesetzt ist. Es können Breaking Changes auftreten.
 ====
 
 == Zielwert
@@ -21,7 +21,7 @@ Als Entwickler möchten Sie Ihre Technologie mit {stackstate-product-name} integ
 +
 [source,bash]
 ----
-export STS_EXPERIMENTAL_STACKPACK=true
+export STS_EXPERIMENTAL_STACKPACKS=true
 ----
 
 

--- a/docs/latest/modules/en/pages/setup/custom-integrations/develop.adoc
+++ b/docs/latest/modules/en/pages/setup/custom-integrations/develop.adoc
@@ -7,7 +7,7 @@ ifdef::ss-ff-stackpacks2_enabled[]
 
 [IMPORTANT]
 ====
-This feature is pre-production and unreleased. It is only available if the environment variable `STS_EXPERIMENTAL_STACKPACK` is set. Breaking changes may occur.
+This feature is pre-production and unreleased. It is only available if the environment variable `STS_EXPERIMENTAL_STACKPACKS` is set. Breaking changes may occur.
 ====
 
 == Goal
@@ -21,7 +21,7 @@ As a developer, you want to integrate your technology with {stackstate-product-n
 +
 [source,bash]
 ----
-export STS_EXPERIMENTAL_STACKPACK=true
+export STS_EXPERIMENTAL_STACKPACKS=true
 ----
 
 

--- a/docs/latest/modules/es/pages/setup/custom-integrations/develop.adoc
+++ b/docs/latest/modules/es/pages/setup/custom-integrations/develop.adoc
@@ -7,7 +7,7 @@ ifdef::ss-ff-stackpacks2_enabled[]
 
 [IMPORTANT]
 ====
-Esta función está en preproducción y no se ha lanzado. Solo está disponible si la variable de entorno `STS_EXPERIMENTAL_STACKPACK` está configurada. Pueden ocurrir cambios disruptivos.
+Esta función está en preproducción y no se ha lanzado. Solo está disponible si la variable de entorno `STS_EXPERIMENTAL_STACKPACKS` está configurada. Pueden ocurrir cambios disruptivos.
 ====
 
 == Meta
@@ -21,7 +21,7 @@ Como desarrollador, deseas integrar tu tecnología con {stackstate-product-name}
 +
 [source,bash]
 ----
-export STS_EXPERIMENTAL_STACKPACK=true
+export STS_EXPERIMENTAL_STACKPACKS=true
 ----
 
 

--- a/docs/latest/modules/fr/pages/setup/custom-integrations/develop.adoc
+++ b/docs/latest/modules/fr/pages/setup/custom-integrations/develop.adoc
@@ -7,7 +7,7 @@ ifdef::ss-ff-stackpacks2_enabled[]
 
 [IMPORTANT]
 ====
-Cette fonctionnalité est en pré-production et non publiée. Elle n'est disponible que si la variable d'environnement `STS_EXPERIMENTAL_STACKPACK` est définie. Des changements majeurs peuvent survenir.
+Cette fonctionnalité est en pré-production et non publiée. Elle n'est disponible que si la variable d'environnement `STS_EXPERIMENTAL_STACKPACKS` est définie. Des changements majeurs peuvent survenir.
 ====
 
 == Objectif
@@ -21,7 +21,7 @@ En tant que développeur, vous souhaitez intégrer votre technologie avec {stack
 +
 [source,bash]
 ----
-export STS_EXPERIMENTAL_STACKPACK=true
+export STS_EXPERIMENTAL_STACKPACKS=true
 ----
 
 

--- a/docs/latest/modules/ja/pages/setup/custom-integrations/develop.adoc
+++ b/docs/latest/modules/ja/pages/setup/custom-integrations/develop.adoc
@@ -7,7 +7,7 @@ ifdef::ss-ff-stackpacks2_enabled[]
 
 [IMPORTANT]
 ====
-この機能はプレプロダクションであり、未リリースです。環境変数`STS_EXPERIMENTAL_STACKPACK`が設定されている場合のみ利用可能です。破壊的変更が発生する可能性があります。
+この機能はプレプロダクションであり、未リリースです。環境変数`STS_EXPERIMENTAL_STACKPACKS`が設定されている場合のみ利用可能です。破壊的変更が発生する可能性があります。
 ====
 
 == 目的
@@ -21,7 +21,7 @@ ifdef::ss-ff-stackpacks2_enabled[]
 +
 [source,bash]
 ----
-export STS_EXPERIMENTAL_STACKPACK=true
+export STS_EXPERIMENTAL_STACKPACKS=true
 ----
 
 

--- a/docs/latest/modules/pt/pages/setup/custom-integrations/develop.adoc
+++ b/docs/latest/modules/pt/pages/setup/custom-integrations/develop.adoc
@@ -7,7 +7,7 @@ ifdef::ss-ff-stackpacks2_enabled[]
 
 [IMPORTANT]
 ====
-Este recurso está em pré-produção e não foi lançado. Está disponível apenas se a variável de ambiente `STS_EXPERIMENTAL_STACKPACK` estiver definida. Mudanças significativas podem ocorrer.
+Este recurso está em pré-produção e não foi lançado. Está disponível apenas se a variável de ambiente `STS_EXPERIMENTAL_STACKPACKS` estiver definida. Mudanças significativas podem ocorrer.
 ====
 
 == Meta
@@ -21,7 +21,7 @@ Como desenvolvedor, você deseja integrar sua tecnologia com {stackstate-product
 +
 [source,bash]
 ----
-export STS_EXPERIMENTAL_STACKPACK=true
+export STS_EXPERIMENTAL_STACKPACKS=true
 ----
 
 

--- a/docs/latest/modules/zh/pages/setup/custom-integrations/develop.adoc
+++ b/docs/latest/modules/zh/pages/setup/custom-integrations/develop.adoc
@@ -7,7 +7,7 @@ ifdef::ss-ff-stackpacks2_enabled[]
 
 [IMPORTANT]
 ====
-此功能为预生产状态，尚未发布。仅在设置了环境变量 `STS_EXPERIMENTAL_STACKPACK` 时可用。可能会发生重大更改。
+此功能为预生产状态，尚未发布。仅在设置了环境变量 `STS_EXPERIMENTAL_STACKPACKS` 时可用。可能会发生重大更改。
 ====
 
 == 目标
@@ -21,7 +21,7 @@ ifdef::ss-ff-stackpacks2_enabled[]
 +
 [source,bash]
 ----
-export STS_EXPERIMENTAL_STACKPACK=true
+export STS_EXPERIMENTAL_STACKPACKS=true
 ----
 
 


### PR DESCRIPTION
Related feature flags in the stackstate CLI have been consolidated and now follow the same experimental feature switch name as in the helm chart.