### PR TITLE
Small customizations

### DIFF
--- a/docs/latest/modules/de/pages/setup/otel/getting-started/getting-started-k8s-operator.adoc
+++ b/docs/latest/modules/de/pages/setup/otel/getting-started/getting-started-k8s-operator.adoc
@@ -142,7 +142,7 @@ spec:
         config:
           scrape_configs:
           - job_name: opentelemetry-collector
-            scrape_interval: 10s
+            scrape_interval: 30s
             static_configs:
             - targets:
               - ${env:MY_POD_IP}:8888

--- a/docs/latest/modules/de/pages/setup/otel/getting-started/getting-started-k8s.adoc
+++ b/docs/latest/modules/de/pages/setup/otel/getting-started/getting-started-k8s.adoc
@@ -93,7 +93,7 @@ config:
       config:
         scrape_configs:
         - job_name: opentelemetry-collector
-          scrape_interval: 10s
+          scrape_interval: 30s
           static_configs:
           - targets:
             - ${env:MY_POD_IP}:8888

--- a/docs/latest/modules/de/pages/setup/otel/getting-started/getting-started-linux.adoc
+++ b/docs/latest/modules/de/pages/setup/otel/getting-started/getting-started-linux.adoc
@@ -110,7 +110,7 @@ receivers:
     config:
       scrape_configs:
       - job_name: 'otel-collector'
-        scrape_interval: 10s
+        scrape_interval: 30s
         static_configs:
         - targets: ['0.0.0.0:8888']
 extensions:

--- a/docs/latest/modules/en/pages/setup/otel/getting-started/getting-started-k8s-operator.adoc
+++ b/docs/latest/modules/en/pages/setup/otel/getting-started/getting-started-k8s-operator.adoc
@@ -154,7 +154,7 @@ spec:
         config:
           scrape_configs:
           - job_name: opentelemetry-collector
-            scrape_interval: 10s
+            scrape_interval: 30s
             static_configs:
             - targets:
               - ${env:MY_POD_IP}:8888

--- a/docs/latest/modules/en/pages/setup/otel/getting-started/getting-started-k8s.adoc
+++ b/docs/latest/modules/en/pages/setup/otel/getting-started/getting-started-k8s.adoc
@@ -98,7 +98,7 @@ config:
       config:
         scrape_configs:
         - job_name: opentelemetry-collector
-          scrape_interval: 10s
+          scrape_interval: 30s
           static_configs:
           - targets:
             - ${env:MY_POD_IP}:8888

--- a/docs/latest/modules/en/pages/setup/otel/getting-started/getting-started-linux.adoc
+++ b/docs/latest/modules/en/pages/setup/otel/getting-started/getting-started-linux.adoc
@@ -110,7 +110,7 @@ receivers:
     config:
       scrape_configs:
       - job_name: 'otel-collector'
-        scrape_interval: 10s
+        scrape_interval: 30s
         static_configs:
         - targets: ['0.0.0.0:8888']
 extensions:

--- a/docs/latest/modules/en/pages/use/views/k8s-traces-perspective.adoc
+++ b/docs/latest/modules/en/pages/use/views/k8s-traces-perspective.adoc
@@ -17,7 +17,7 @@ image::k8s/k8s-traces-perspective.png[Traces perspective]
 
 == Filter traces
 
-The trace filters allow you to refine the traces displayed based on span status (Error, Ok or Unset), parent type (External, Internal or Root) and duration.
+The trace filters allow you to refine the traces displayed based on span status (Error, Ok or Unset), span attributes, and duration.
 
 In addition to these filters, the traces match the *Time Window* selected in the timeline control at the bottom of the SUSE Observability UI.
 Adjust the time window to show only traces from that time.

--- a/docs/latest/modules/es/pages/setup/otel/getting-started/getting-started-k8s-operator.adoc
+++ b/docs/latest/modules/es/pages/setup/otel/getting-started/getting-started-k8s-operator.adoc
@@ -142,7 +142,7 @@ spec:
         config:
           scrape_configs:
           - job_name: opentelemetry-collector
-            scrape_interval: 10s
+            scrape_interval: 30s
             static_configs:
             - targets:
               - ${env:MY_POD_IP}:8888

--- a/docs/latest/modules/es/pages/setup/otel/getting-started/getting-started-k8s.adoc
+++ b/docs/latest/modules/es/pages/setup/otel/getting-started/getting-started-k8s.adoc
@@ -93,7 +93,7 @@ config:
       config:
         scrape_configs:
         - job_name: opentelemetry-collector
-          scrape_interval: 10s
+          scrape_interval: 30s
           static_configs:
           - targets:
             - ${env:MY_POD_IP}:8888

--- a/docs/latest/modules/es/pages/setup/otel/getting-started/getting-started-linux.adoc
+++ b/docs/latest/modules/es/pages/setup/otel/getting-started/getting-started-linux.adoc
@@ -110,7 +110,7 @@ receivers:
     config:
       scrape_configs:
       - job_name: 'otel-collector'
-        scrape_interval: 10s
+        scrape_interval: 30s
         static_configs:
         - targets: ['0.0.0.0:8888']
 extensions:

--- a/docs/latest/modules/fr/pages/setup/otel/getting-started/getting-started-k8s-operator.adoc
+++ b/docs/latest/modules/fr/pages/setup/otel/getting-started/getting-started-k8s-operator.adoc
@@ -142,7 +142,7 @@ spec:
         config:
           scrape_configs:
           - job_name: opentelemetry-collector
-            scrape_interval: 10s
+            scrape_interval: 30s
             static_configs:
             - targets:
               - ${env:MY_POD_IP}:8888

--- a/docs/latest/modules/fr/pages/setup/otel/getting-started/getting-started-k8s.adoc
+++ b/docs/latest/modules/fr/pages/setup/otel/getting-started/getting-started-k8s.adoc
@@ -93,7 +93,7 @@ config:
       config:
         scrape_configs:
         - job_name: opentelemetry-collector
-          scrape_interval: 10s
+          scrape_interval: 30s
           static_configs:
           - targets:
             - ${env:MY_POD_IP}:8888

--- a/docs/latest/modules/fr/pages/setup/otel/getting-started/getting-started-linux.adoc
+++ b/docs/latest/modules/fr/pages/setup/otel/getting-started/getting-started-linux.adoc
@@ -110,7 +110,7 @@ receivers:
     config:
       scrape_configs:
       - job_name: 'otel-collector'
-        scrape_interval: 10s
+        scrape_interval: 30s
         static_configs:
         - targets: ['0.0.0.0:8888']
 extensions:

--- a/docs/latest/modules/ja/pages/setup/otel/getting-started/getting-started-k8s-operator.adoc
+++ b/docs/latest/modules/ja/pages/setup/otel/getting-started/getting-started-k8s-operator.adoc
@@ -142,7 +142,7 @@ spec:
         config:
           scrape_configs:
           - job_name: opentelemetry-collector
-            scrape_interval: 10s
+            scrape_interval: 30s
             static_configs:
             - targets:
               - ${env:MY_POD_IP}:8888

--- a/docs/latest/modules/ja/pages/setup/otel/getting-started/getting-started-k8s.adoc
+++ b/docs/latest/modules/ja/pages/setup/otel/getting-started/getting-started-k8s.adoc
@@ -93,7 +93,7 @@ config:
       config:
         scrape_configs:
         - job_name: opentelemetry-collector
-          scrape_interval: 10s
+          scrape_interval: 30s
           static_configs:
           - targets:
             - ${env:MY_POD_IP}:8888

--- a/docs/latest/modules/ja/pages/setup/otel/getting-started/getting-started-linux.adoc
+++ b/docs/latest/modules/ja/pages/setup/otel/getting-started/getting-started-linux.adoc
@@ -110,7 +110,7 @@ receivers:
     config:
       scrape_configs:
       - job_name: 'otel-collector'
-        scrape_interval: 10s
+        scrape_interval: 30s
         static_configs:
         - targets: ['0.0.0.0:8888']
 extensions:

--- a/docs/latest/modules/pt/pages/setup/otel/getting-started/getting-started-k8s-operator.adoc
+++ b/docs/latest/modules/pt/pages/setup/otel/getting-started/getting-started-k8s-operator.adoc
@@ -142,7 +142,7 @@ spec:
         config:
           scrape_configs:
           - job_name: opentelemetry-collector
-            scrape_interval: 10s
+            scrape_interval: 30s
             static_configs:
             - targets:
               - ${env:MY_POD_IP}:8888

--- a/docs/latest/modules/pt/pages/setup/otel/getting-started/getting-started-k8s.adoc
+++ b/docs/latest/modules/pt/pages/setup/otel/getting-started/getting-started-k8s.adoc
@@ -93,7 +93,7 @@ config:
       config:
         scrape_configs:
         - job_name: opentelemetry-collector
-          scrape_interval: 10s
+          scrape_interval: 30s
           static_configs:
           - targets:
             - ${env:MY_POD_IP}:8888

--- a/docs/latest/modules/pt/pages/setup/otel/getting-started/getting-started-linux.adoc
+++ b/docs/latest/modules/pt/pages/setup/otel/getting-started/getting-started-linux.adoc
@@ -110,7 +110,7 @@ receivers:
     config:
       scrape_configs:
       - job_name: 'otel-collector'
-        scrape_interval: 10s
+        scrape_interval: 30s
         static_configs:
         - targets: ['0.0.0.0:8888']
 extensions:

--- a/docs/latest/modules/zh/pages/setup/otel/getting-started/getting-started-k8s-operator.adoc
+++ b/docs/latest/modules/zh/pages/setup/otel/getting-started/getting-started-k8s-operator.adoc
@@ -142,7 +142,7 @@ spec:
         config:
           scrape_configs:
           - job_name: opentelemetry-collector
-            scrape_interval: 10s
+            scrape_interval: 30s
             static_configs:
             - targets:
               - ${env:MY_POD_IP}:8888

--- a/docs/latest/modules/zh/pages/setup/otel/getting-started/getting-started-k8s.adoc
+++ b/docs/latest/modules/zh/pages/setup/otel/getting-started/getting-started-k8s.adoc
@@ -93,7 +93,7 @@ config:
       config:
         scrape_configs:
         - job_name: opentelemetry-collector
-          scrape_interval: 10s
+          scrape_interval: 30s
           static_configs:
           - targets:
             - ${env:MY_POD_IP}:8888

--- a/docs/latest/modules/zh/pages/setup/otel/getting-started/getting-started-linux.adoc
+++ b/docs/latest/modules/zh/pages/setup/otel/getting-started/getting-started-linux.adoc
@@ -110,7 +110,7 @@ receivers:
     config:
       scrape_configs:
       - job_name: 'otel-collector'
-        scrape_interval: 10s
+        scrape_interval: 30s
         static_configs:
         - targets: ['0.0.0.0:8888']
 extensions:


### PR DESCRIPTION
* Dropping span parent type reference from docs (this feature has not been available for a long time)
* Example scrape interval was 10s, we use 30s for our agent which also significantly reduces the amount of data