### PR TITLE
STAC-24724: Add Firefox certificate store guidance to extension troubleshooting

### DIFF
--- a/docs/latest/modules/en/pages/setup/install-stackstate/extension-troubleshooting.adoc
+++ b/docs/latest/modules/en/pages/setup/install-stackstate/extension-troubleshooting.adoc
@@ -32,3 +32,8 @@ The configuration for SUSE Observability may sometimes not yield a valid connect
 
 * The Rancher host is not configured as an allowed origin for SUSE Observability.  You can fix this by adding it to the `stackstate.allowedOrigins` list in the helm values, or by passing `--set stackstate.allowedOrigins={"https://<rancher-url>"}` to the deployment command.
 * SUSE Observability is not accessible from the browser. For example, the root certificate has not been installed.
+** Firefox does not use the OS certificate store. If Chrome works but Firefox does not:
+*** Open `about:preferences#privacy` > *Certificates* > *View Certificates*
+*** Go to *Authorities* > *Import* and select the CA certificate file
+*** Check *Trust this CA to identify websites* and click OK
+*** Or set `security.enterprise_roots.enabled` to `true` in `about:config`

--- a/docs/latest/modules/en/pages/setup/install-stackstate/extension-troubleshooting.adoc
+++ b/docs/latest/modules/en/pages/setup/install-stackstate/extension-troubleshooting.adoc
@@ -36,4 +36,4 @@ The configuration for SUSE Observability may sometimes not yield a valid connect
 *** Open `about:preferences#privacy` > *Certificates* > *View Certificates*
 *** Go to *Authorities* > *Import* and select the CA certificate file
 *** Check *Trust this CA to identify websites* and click OK
-*** Or set `security.enterprise_roots.enabled` to `true` in `about:config`
+*** Or set `security.enterprise_roots.enabled` to `true` in `about:config` to make Firefox read certificates from the OS trust store


### PR DESCRIPTION
## Summary
- Adds Firefox-specific certificate import steps to the extension troubleshooting page
- Firefox uses its own certificate store separate from the OS — customers with self-signed certs see the extension work in Chrome but fail in Firefox

## Test plan
- [ ] Verify AsciiDoc renders correctly in the docs site
- [ ] Confirm the `about:config` and `about:preferences` paths are current for latest Firefox

🤖 Generated with [Claude Code](https://claude.com/claude-code)