### PR TITLE
STAC-24888 Support Application Collection Kafka image in perf collector

### DIFF
--- a/docs/latest/modules/en/attachments/suse-observability_performance_collector.sh
+++ b/docs/latest/modules/en/attachments/suse-observability_performance_collector.sh
@@ -147,6 +147,33 @@ collect_network_performance() {
     done
 }
 
+# Detect Kafka layout (Bitnami vs SUSE Application Collection) from the first kafka pod.
+# Sets KAFKA_BIN_DIR and KAFKA_DATA_DIR globally.
+detect_kafka_paths() {
+    local first_pod
+    first_pod=$(kubectl -n "$NAMESPACE" get pods -l app.kubernetes.io/component==kafka -o jsonpath="{.items[0].metadata.name}" 2>/dev/null)
+    if [ -z "$first_pod" ]; then
+      techo "No kafka pods found; defaulting to Bitnami paths."
+      KAFKA_BIN_DIR="/opt/bitnami/kafka/bin"
+      KAFKA_DATA_DIR="/bitnami/kafka"
+      return
+    fi
+
+    if kubectl -n "$NAMESPACE" exec "$first_pod" -c kafka -- sh -c "test -d /opt/bitnami/kafka/bin" &>/dev/null; then
+      KAFKA_BIN_DIR="/opt/bitnami/kafka/bin"
+      KAFKA_DATA_DIR="/bitnami/kafka"
+      techo "Detected Bitnami Kafka image (bin: $KAFKA_BIN_DIR, data: $KAFKA_DATA_DIR)."
+    elif kubectl -n "$NAMESPACE" exec "$first_pod" -c kafka -- sh -c "test -d /usr/share/kafka/bin" &>/dev/null; then
+      KAFKA_BIN_DIR="/usr/share/kafka/bin"
+      KAFKA_DATA_DIR="/data/kafka"
+      techo "Detected SUSE Application Collection Kafka image (bin: $KAFKA_BIN_DIR, data: $KAFKA_DATA_DIR)."
+    else
+      techo "Could not detect Kafka image layout from pod '$first_pod'; defaulting to Bitnami paths."
+      KAFKA_BIN_DIR="/opt/bitnami/kafka/bin"
+      KAFKA_DATA_DIR="/bitnami/kafka"
+    fi
+}
+
 create_kafka_topics() {
   # Topics cannot be removed because topic deletion is disabled by default on the broker
     techo "Creating topics"
@@ -161,7 +188,7 @@ create_kafka_topics() {
     for pod in $PODS; do
       # Topics are pinned to a particular broker using replica-assignment, allowing to test localhost/networked traffic
         kubectl -n "$NAMESPACE" exec "$pod" -c "kafka" -- bash -xc "\
-          JMX_PORT="" /opt/bitnami/kafka/bin/kafka-topics.sh --create --if-not-exists --topic perf-test-topic-$index --bootstrap-server localhost:9092 --replica-assignment $index --config retention.ms=300000 --config retention.bytes=1073741824 \
+          JMX_PORT="" $KAFKA_BIN_DIR/kafka-topics.sh --create --if-not-exists --topic perf-test-topic-$index --bootstrap-server localhost:9092 --replica-assignment $index --config retention.ms=300000 --config retention.bytes=1073741824 \
         " > "$SUBDIR/$pod.log" 2>&1
 
         ((index++))
@@ -181,7 +208,7 @@ collect_kafka_broker_performance_local() {
     index=0
     for pod in $PODS; do
        kubectl -n "$NAMESPACE" exec "$pod" -c "kafka" -- bash -xc "\
-                 JMX_PORT="" /opt/bitnami/kafka/bin/kafka-producer-perf-test.sh --topic perf-test-topic-$index --num-records 500000 --record-size 1024 --throughput -1 --producer-props bootstrap.servers=localhost:9092 acks=1\
+                 JMX_PORT="" $KAFKA_BIN_DIR/kafka-producer-perf-test.sh --topic perf-test-topic-$index --num-records 500000 --record-size 1024 --throughput -1 --producer-props bootstrap.servers=localhost:9092 acks=1\
                " > "$SUBDIR/$pod.log" 2>&1
 
         ((index++))
@@ -209,7 +236,7 @@ collect_kafka_broker_performance_remote() {
       ((prev_index--))
       for pod in $PODS; do
           kubectl -n "$NAMESPACE" exec "$pod" -c "kafka" -- bash -xc "\
-            JMX_PORT="" /opt/bitnami/kafka/bin/kafka-producer-perf-test.sh --topic perf-test-topic-$prev_index --num-records 500000 --record-size 1024 --throughput -1 --producer-props bootstrap.servers=localhost:9092 acks=1\
+            JMX_PORT="" $KAFKA_BIN_DIR/kafka-producer-perf-test.sh --topic perf-test-topic-$prev_index --num-records 500000 --record-size 1024 --throughput -1 --producer-props bootstrap.servers=localhost:9092 acks=1\
           " > "$SUBDIR/$pod.log" 2>&1
           prev_index=$index
           ((index++))
@@ -333,8 +360,9 @@ collect_disk_performance "HDFS Disk Buffered"       "hdfs-dn"    "datanode" "/ha
 collect_disk_performance "HDFS Disk Direct"         "hdfs-dn"    "datanode" "/hadoop-data/testfile"      "oflag=direct"
 collect_network_performance "HDFS Network"             "hdfs-dn"    "datanode"
 
-collect_disk_performance "Kafka Disk Buffered"      "kafka"      "kafka"    "/bitnami/kafka/testfile"
-collect_disk_performance "Kafka Disk Direct"        "kafka"      "kafka"    "/bitnami/kafka/testfile"    "oflag=direct"
+detect_kafka_paths
+collect_disk_performance "Kafka Disk Buffered"      "kafka"      "kafka"    "$KAFKA_DATA_DIR/testfile"
+collect_disk_performance "Kafka Disk Direct"        "kafka"      "kafka"    "$KAFKA_DATA_DIR/testfile"   "oflag=direct"
 # The kafka images is missing both the `hostname` command and `nc`, so we skip this one
 # collect_network_performance "Kafka Network"            "kafka"      "kafka"
 collect_kafka_broker_performance


### PR DESCRIPTION
## Summary

- Detect the Kafka image layout at runtime in `suse-observability_performance_collector.sh` by `test -d`'ing the bin directory inside the first kafka pod.
- Picks between Bitnami (`/opt/bitnami/kafka/bin`, `/bitnami/kafka`) and SUSE Application Collection (`/usr/share/kafka/bin`, `/data/kafka`) paths and uses them for both the Kafka disk tests and the `kafka-topics.sh` / `kafka-producer-perf-test.sh` invocations.
- Falls back to Bitnami paths when no kafka pod is found or neither directory exists.

Previously the script hardcoded Bitnami paths and failed against the new Application Collection Kafka image where the data directory and CLI live under different prefixes.

## Test plan

- [ ] Run against a deployment using the Bitnami Kafka image and confirm disk + producer tests still pass.
- [ ] Run against a deployment using the SUSE Application Collection Kafka image and confirm the detection log line reports the AppCollection paths and the tests complete successfully.

Testing against 2.10.0 (Kafka image from Application Collection)
```
❯ bash suse-observability_performance_collector.sh stac-24888-210
Running performance tests in kubernetes context: sandbox-main.sandbox.stackstate.io
Collecting data in stac-24888-210_performance_2026-05-22_12-44-14Z
2026-05-22 14:44:14: StackGraph Disk Buffered performance...
2026-05-22 14:44:16: No pods found for component 'stackgraph', skipping.
2026-05-22 14:44:16: StackGraph Disk Direct performance...
2026-05-22 14:44:17: No pods found for component 'stackgraph', skipping.
2026-05-22 14:44:17: HDFS Disk Buffered performance...
2026-05-22 14:44:38: HDFS Disk Direct performance...
2026-05-22 14:45:12: HDFS Network performance...
2026-05-22 14:45:37: Detected SUSE Application Collection Kafka image (bin: /usr/share/kafka/bin, data: /data/kafka).
2026-05-22 14:45:37: Kafka Disk Buffered performance...
2026-05-22 14:45:58: Kafka Disk Direct performance...
2026-05-22 14:46:33: Kafka Topic performance...
2026-05-22 14:46:33: Creating topics
2026-05-22 14:46:44: Performance testing throughput to topic on localhost
2026-05-22 14:47:25: Performance testing throughput to topic on remote broker
2026-05-22 14:48:00: Generating summary...
2026-05-22 14:48:00: Summary written to stac-24888-210_performance_2026-05-22_12-44-14Z/summary.log
=== SUSE Observability Performance Summary ===
Date: 2026-05-22T12:48:00Z

--- Hdfs Disk Buffered ---
  suse-observability-hbase-hdfs-dn-0                           153 MB/s
  suse-observability-hbase-hdfs-dn-1                           152 MB/s
  suse-observability-hbase-hdfs-dn-2                           153 MB/s

--- Hdfs Disk Direct ---
  suse-observability-hbase-hdfs-dn-0                           65.8 MB/s
  suse-observability-hbase-hdfs-dn-1                           62.8 MB/s
  suse-observability-hbase-hdfs-dn-2                           65.6 MB/s

--- Kafka Disk Buffered ---
  suse-observability-kafka-0                                   154 MB/s
  suse-observability-kafka-1                                   154 MB/s
  suse-observability-kafka-2                                   154 MB/s

--- Kafka Disk Direct ---
  suse-observability-kafka-0                                   62.4 MB/s
  suse-observability-kafka-1                                   63.7 MB/s
  suse-observability-kafka-2                                   61.5 MB/s

--- Kafka Producer Local ---
  suse-observability-kafka-0                                   50766.575287 records/sec (49.58 MB/sec), 549.76 ms avg latency
  suse-observability-kafka-1                                   47460.844803 records/sec (46.35 MB/sec), 592.71 ms avg latency
  suse-observability-kafka-2                                   50454.086781 records/sec (49.27 MB/sec), 554.79 ms avg latency

--- Kafka Producer Remote ---
  suse-observability-kafka-0                                   60379.181258 records/sec (58.96 MB/sec), 456.42 ms avg latency
  suse-observability-kafka-1                                   60819.851600 records/sec (59.39 MB/sec), 452.68 ms avg latency
  suse-observability-kafka-2                                   59908.938414 records/sec (58.50 MB/sec), 460.72 ms avg latency

--- Hdfs Network ---
  suse-observability-hbase-hdfs-dn-0 -> suse-observability-hbase-hdfs-dn-1 484 MB/s
  suse-observability-hbase-hdfs-dn-1 -> suse-observability-hbase-hdfs-dn-2 489 MB/s
  suse-observability-hbase-hdfs-dn-2 -> suse-observability-hbase-hdfs-dn-0 479 MB/s

Creating archive stac-24888-210_performance_2026-05-22_12-44-14Z.tar.gz...
Archive created.
Cleaning up the output directory...
Output directory removed.
All information collected in the stac-24888-210_performance_2026-05-22_12-44-14Z.tar.gz
```

Testing against 2.9
```
❯ bash suse-observability_performance_collector.sh stac-24888-29
Running performance tests in kubernetes context: sandbox-main.sandbox.stackstate.io
Collecting data in stac-24888-29_performance_2026-05-22_12-52-41Z
2026-05-22 14:52:41: StackGraph Disk Buffered performance...
2026-05-22 14:52:43: No pods found for component 'stackgraph', skipping.
2026-05-22 14:52:43: StackGraph Disk Direct performance...
2026-05-22 14:52:44: No pods found for component 'stackgraph', skipping.
2026-05-22 14:52:44: HDFS Disk Buffered performance...
2026-05-22 14:53:05: HDFS Disk Direct performance...
2026-05-22 14:53:41: HDFS Network performance...
2026-05-22 14:54:05: Detected Bitnami Kafka image (bin: /opt/bitnami/kafka/bin, data: /bitnami/kafka).
2026-05-22 14:54:05: Kafka Disk Buffered performance...
2026-05-22 14:54:26: Kafka Disk Direct performance...
2026-05-22 14:55:00: Kafka Topic performance...
2026-05-22 14:55:00: Creating topics
2026-05-22 14:55:11: Performance testing throughput to topic on localhost
2026-05-22 14:55:51: Performance testing throughput to topic on remote broker
2026-05-22 14:56:25: Generating summary...
2026-05-22 14:56:26: Summary written to stac-24888-29_performance_2026-05-22_12-52-41Z/summary.log
=== SUSE Observability Performance Summary ===
Date: 2026-05-22T12:56:25Z

--- Hdfs Disk Buffered ---
  suse-observability-hbase-hdfs-dn-0                           153 MB/s
  suse-observability-hbase-hdfs-dn-1                           154 MB/s
  suse-observability-hbase-hdfs-dn-2                           153 MB/s

--- Hdfs Disk Direct ---
  suse-observability-hbase-hdfs-dn-0                           59.4 MB/s
  suse-observability-hbase-hdfs-dn-1                           59.0 MB/s
  suse-observability-hbase-hdfs-dn-2                           65.6 MB/s

--- Kafka Disk Buffered ---
  suse-observability-kafka-0                                   154 MB/s
  suse-observability-kafka-1                                   153 MB/s
  suse-observability-kafka-2                                   154 MB/s

--- Kafka Disk Direct ---
  suse-observability-kafka-0                                   66.1 MB/s
  suse-observability-kafka-1                                   65.8 MB/s
  suse-observability-kafka-2                                   64.1 MB/s

--- Kafka Producer Local ---
  suse-observability-kafka-0                                   51292.572835 records/sec (50.09 MB/sec), 546.10 ms avg latency
  suse-observability-kafka-1                                   49169.043170 records/sec (48.02 MB/sec), 570.86 ms avg latency
  suse-observability-kafka-2                                   50135.365487 records/sec (48.96 MB/sec), 556.38 ms avg latency

--- Kafka Producer Remote ---
  suse-observability-kafka-0                                   61781.786729 records/sec (60.33 MB/sec), 445.50 ms avg latency
  suse-observability-kafka-1                                   60613.407686 records/sec (59.19 MB/sec), 455.82 ms avg latency
  suse-observability-kafka-2                                   61364.752086 records/sec (59.93 MB/sec), 450.54 ms avg latency

--- Hdfs Network ---
  suse-observability-hbase-hdfs-dn-0 -> suse-observability-hbase-hdfs-dn-1 474 MB/s
  suse-observability-hbase-hdfs-dn-1 -> suse-observability-hbase-hdfs-dn-2 502 MB/s
  suse-observability-hbase-hdfs-dn-2 -> suse-observability-hbase-hdfs-dn-0 474 MB/s

Creating archive stac-24888-29_performance_2026-05-22_12-52-41Z.tar.gz...
Archive created.
Cleaning up the output directory...
Output directory removed.
All information collected in the stac-24888-29_performance_2026-05-22_12-52-41Z.tar.gz
```