### PR TITLE
STAC-25340: document backup enabled toggles instead of invalid 1970 cron

### DIFF
--- a/docs/latest/modules/en/pages/setup/data-management/backup_restore/backup_enable.adoc
+++ b/docs/latest/modules/en/pages/setup/data-management/backup_restore/backup_enable.adoc
@@ -358,14 +358,13 @@ The backup retention delta can be configured using the Helm value `backup.stackG
 
 === Disable scheduled backups
 
-To disable scheduled StackGraph backups, set the Helm value `backup.stackGraph.scheduled.enabled` to `false`:
+To disable scheduled StackGraph backups, set the Helm value `backup.stackGraph.enabled` to `false`:
 
 [,yaml]
 ----
 backup:
   stackGraph:
-    scheduled:
-      enabled: false
+    enabled: false
 ----
 
 == Settings
@@ -376,11 +375,11 @@ Settings backups are lightweight (typically only several megabytes) and quick to
 
 [NOTE]
 ====
-*Settings backups are enabled by default* and are controlled independently of the `global.backup.enabled` value by `backup.configuration.scheduled.enabled` (default `true`):
+*Settings backups are enabled by default* and are controlled independently of the `global.backup.enabled` value by `backup.configuration.enabled` (default `true`):
 
 * When `global.backup.enabled` is `true`: Settings backups are stored, via the S3 Proxy, to your configured storage backend (AWS S3, Azure Blob Storage, or Kubernetes Persistent Volume)
 * When `global.backup.enabled` is `false`: Settings backups are stored, via the S3 Proxy, to a dedicated Kubernetes Persistent Volume
-* When `backup.configuration.scheduled.enabled` is `false`: Settings backups are disabled. If every other backup is also disabled, the S3 Proxy is no longer deployed.
+* When `backup.configuration.enabled` is `false`: Settings backups are disabled. If every other backup is also disabled, the S3 Proxy is no longer deployed.
 ====
 
 === Backup schedule
@@ -418,14 +417,13 @@ backup:
 
 === Disable scheduled backups
 
-To disable scheduled settings backups, set the Helm value `backup.configuration.scheduled.enabled` to `false`:
+To disable scheduled settings backups, set the Helm value `backup.configuration.enabled` to `false`:
 
 [,yaml]
 ----
 backup:
   configuration:
-    scheduled:
-      enabled: false
+    enabled: false
 ----
 
 == Metrics (Victoria Metrics)
@@ -540,12 +538,11 @@ The retention time and number of snapshots kept can be configured using the foll
 
 === Disable scheduled snapshots
 
-To disable scheduled Elasticsearch snapshots, set the Helm value `backup.elasticsearch.scheduled.enabled` to `false`:
+To disable scheduled Elasticsearch snapshots, set the Helm value `backup.elasticsearch.enabled` to `false`:
 
 [,yaml]
 ----
 backup:
   elasticsearch:
-    scheduled:
-      enabled: false
+    enabled: false
 ----

--- a/docs/latest/modules/en/pages/setup/data-management/backup_restore/backup_enable.adoc
+++ b/docs/latest/modules/en/pages/setup/data-management/backup_restore/backup_enable.adoc
@@ -358,14 +358,14 @@ The backup retention delta can be configured using the Helm value `backup.stackG
 
 === Disable scheduled backups
 
-To disable scheduled StackGraph backups, set the backup schedule to a date far in the past using the Helm value `backup.stackGraph.scheduled.schedule`:
+To disable scheduled StackGraph backups, set the Helm value `backup.stackGraph.scheduled.enabled` to `false`:
 
 [,yaml]
 ----
 backup:
   stackGraph:
     scheduled:
-      schedule: '0 0 1 1 1970'  # January 1, 1970 (epoch start)
+      enabled: false
 ----
 
 == Settings
@@ -376,10 +376,11 @@ Settings backups are lightweight (typically only several megabytes) and quick to
 
 [NOTE]
 ====
-*Settings backups are always enabled*, regardless of the `global.backup.enabled` value:
+*Settings backups are enabled by default* and are controlled independently of the `global.backup.enabled` value by `backup.configuration.scheduled.enabled` (default `true`):
 
 * When `global.backup.enabled` is `true`: Settings backups are stored, via the S3 Proxy, to your configured storage backend (AWS S3, Azure Blob Storage, or Kubernetes Persistent Volume)
 * When `global.backup.enabled` is `false`: Settings backups are stored, via the S3 Proxy, to a dedicated Kubernetes Persistent Volume
+* When `backup.configuration.scheduled.enabled` is `false`: Settings backups are disabled. If every other backup is also disabled, the S3 Proxy is no longer deployed.
 ====
 
 === Backup schedule
@@ -417,14 +418,14 @@ backup:
 
 === Disable scheduled backups
 
-To disable scheduled settings backups, set the backup schedule to a date far in the past using the Helm value `backup.configuration.scheduled.schedule`:
+To disable scheduled settings backups, set the Helm value `backup.configuration.scheduled.enabled` to `false`:
 
 [,yaml]
 ----
 backup:
   configuration:
     scheduled:
-      schedule: '0 0 1 1 1970'  # January 1, 1970 (epoch start)
+      enabled: false
 ----
 
 == Metrics (Victoria Metrics)
@@ -479,20 +480,16 @@ victoria-metrics-1:
 
 === Disable scheduled backups
 
-To disable scheduled Victoria Metrics backups, set the backup schedules for both instances to a date far in the past:
+To disable scheduled Victoria Metrics backups, set `backup.enabled` to `false` for each instance. Backups are configured per instance, so you can disable one instance while keeping the other:
 
 [,yaml]
 ----
 victoria-metrics-0:
   backup:
-    scheduled:
-      hourly: '0 0 1 1 1970'  # January 1, 1970 (epoch start)
-      daily: '0 0 1 1 1970'   # January 1, 1970 (epoch start)
+    enabled: false
 victoria-metrics-1:
   backup:
-    scheduled:
-      hourly: '0 0 1 1 1970'  # January 1, 1970 (epoch start)
-      daily: '0 0 1 1 1970'   # January 1, 1970 (epoch start)
+    enabled: false
 ----
 
 == OpenTelemetry (ClickHouse)
@@ -514,15 +511,13 @@ The backup retention can be configured using the Helm value `clickhouse.backup.c
 
 === Disable scheduled backups
 
-To disable scheduled ClickHouse backups, set both full and incremental backup schedules to a date far in the past:
+To disable scheduled ClickHouse backups, set the Helm value `clickhouse.backup.enabled` to `false`:
 
 [,yaml]
 ----
 clickhouse:
   backup:
-    scheduled:
-      full_schedule: '0 0 1 1 1970'         # January 1, 1970 (epoch start)
-      incremental_schedule: '0 0 1 1 1970'  # January 1, 1970 (epoch start)
+    enabled: false
 ----
 
 == Telemetry data (Elasticsearch)
@@ -545,12 +540,12 @@ The retention time and number of snapshots kept can be configured using the foll
 
 === Disable scheduled snapshots
 
-To disable scheduled Elasticsearch snapshots, set the snapshot schedule to a date far in the past using the Helm value `backup.elasticsearch.scheduled.schedule`:
+To disable scheduled Elasticsearch snapshots, set the Helm value `backup.elasticsearch.scheduled.enabled` to `false`:
 
 [,yaml]
 ----
 backup:
   elasticsearch:
     scheduled:
-      schedule: '0 0 1 1 1970'  # January 1, 1970 (epoch start)
+      enabled: false
 ----

--- a/docs/latest/modules/en/pages/setup/data-management/backup_restore/configuration_backup.adoc
+++ b/docs/latest/modules/en/pages/setup/data-management/backup_restore/configuration_backup.adoc
@@ -72,13 +72,13 @@ By default 365 days of backups are retained, this can be modified via the Helm v
 ----
 backup:
   configuration:
+    # backup.configuration.enabled -- Enable scheduled configuration backups (if `backup.enabled` is set to `true`).
+    enabled: true
     # backup.configuration.bucketName -- Name of the bucket to store configuration backups (needs to be a globally unique bucket when using Amazon S3).
     bucketName: 'sts-configuration-backup'
     # backup.configuration.maxLocalFiles -- The maximum number of configuration backup files stored on the PVC for the configuration backup (which is only of limited size, see backup.configuration.scheduled.pvc.size)
     maxLocalFiles: 10
     scheduled:
-      # backup.configuration.scheduled.enabled -- Enable scheduled configuration backups (if `backup.enabled` is set to `true`).
-      enabled: true
       #_ backup.configuration.scheduled.schedule __ Cron schedule for automatic configuration backups in [Kubernetes cron schedule syntax](https://kubernetes.io/docs/concepts/workloads/controllers/cron-jobs/#cron-schedule-syntax).
       schedule: '0 4 * * *'
       # backup.configuration.scheduled.backupRetentionTimeDelta -- Time to keep configuration backups in object storage. The value is passed to GNU date tool to determine a specific date, and files older than this date will be deleted.

--- a/docs/latest/modules/en/pages/setup/data-management/backup_restore/kubernetes_backup.adoc
+++ b/docs/latest/modules/en/pages/setup/data-management/backup_restore/kubernetes_backup.adoc
@@ -216,14 +216,13 @@ The backup retention delta can be configured using the Helm value `backup.stackG
 
 === Disable scheduled backups
 
-To disable scheduled StackGraph backups, set the Helm value `backup.stackGraph.scheduled.enabled` to `false`:
+To disable scheduled StackGraph backups, set the Helm value `backup.stackGraph.enabled` to `false`:
 
 [,yaml]
 ----
 backup:
   stackGraph:
-    scheduled:
-      enabled: false
+    enabled: false
 ----
 
 == Metrics (Victoria Metrics)
@@ -335,14 +334,13 @@ The configuration snippets provided in the section xref:/setup/data-management/b
 
 === Disable scheduled snapshots
 
-To disable scheduled Elasticsearch snapshots, set the Helm value `backup.elasticsearch.scheduled.enabled` to `false`:
+To disable scheduled Elasticsearch snapshots, set the Helm value `backup.elasticsearch.enabled` to `false`:
 
 [,yaml]
 ----
 backup:
   elasticsearch:
-    scheduled:
-      enabled: false
+    enabled: false
 ----
 
 === Snapshot schedule

--- a/docs/latest/modules/en/pages/setup/data-management/backup_restore/kubernetes_backup.adoc
+++ b/docs/latest/modules/en/pages/setup/data-management/backup_restore/kubernetes_backup.adoc
@@ -216,14 +216,14 @@ The backup retention delta can be configured using the Helm value `backup.stackG
 
 === Disable scheduled backups
 
-To disable scheduled StackGraph backups, set the backup schedule to a date far in the past using the Helm value `backup.stackGraph.scheduled.schedule`:
+To disable scheduled StackGraph backups, set the Helm value `backup.stackGraph.scheduled.enabled` to `false`:
 
 [,yaml]
 ----
 backup:
   stackGraph:
     scheduled:
-      schedule: '0 0 1 1 1970'  # January 1, 1970 (epoch start)
+      enabled: false
 ----
 
 == Metrics (Victoria Metrics)
@@ -279,20 +279,16 @@ victoria-metrics-1:
 
 === Disable scheduled backups
 
-To disable scheduled Victoria Metrics backups, set the backup schedules for both instances to a date far in the past:
+To disable scheduled Victoria Metrics backups, set `backup.enabled` to `false` for each instance. Backups are configured per instance, so you can disable one instance while keeping the other:
 
 [,yaml]
 ----
 victoria-metrics-0:
   backup:
-    scheduled:
-      hourly: '0 0 1 1 1970'  # January 1, 1970 (epoch start)
-      daily: '0 0 1 1 1970'   # January 1, 1970 (epoch start)
+    enabled: false
 victoria-metrics-1:
   backup:
-    scheduled:
-      hourly: '0 0 1 1 1970'  # January 1, 1970 (epoch start)
-      daily: '0 0 1 1 1970'   # January 1, 1970 (epoch start)
+    enabled: false
 ----
 
 == OpenTelemetry (ClickHouse)
@@ -322,15 +318,13 @@ The backup retention can be configured using the Helm value `clickhouse.backup.c
 
 === Disable scheduled backups
 
-To disable scheduled ClickHouse backups, set both full and incremental backup schedules to a date far in the past:
+To disable scheduled ClickHouse backups, set the Helm value `clickhouse.backup.enabled` to `false`:
 
 [,yaml]
 ----
 clickhouse:
   backup:
-    scheduled:
-      full_schedule: '0 0 1 1 1970'         # January 1, 1970 (epoch start)
-      incremental_schedule: '0 0 1 1 1970'  # January 1, 1970 (epoch start)
+    enabled: false
 ----
 
 == Telemetry data (Elasticsearch)
@@ -341,14 +335,14 @@ The configuration snippets provided in the section xref:/setup/data-management/b
 
 === Disable scheduled snapshots
 
-To disable scheduled Elasticsearch snapshots, set the snapshot schedule to a date far in the past using the Helm value `backup.elasticsearch.scheduled.schedule`:
+To disable scheduled Elasticsearch snapshots, set the Helm value `backup.elasticsearch.scheduled.enabled` to `false`:
 
 [,yaml]
 ----
 backup:
   elasticsearch:
     scheduled:
-      schedule: '0 0 1 1 1970'  # January 1, 1970 (epoch start)
+      enabled: false
 ----
 
 === Snapshot schedule


### PR DESCRIPTION
## Summary

Fixes the backup-disable documentation for [STAC-25340](https://stackstate.atlassian.net/browse/STAC-25340). The current docs tell customers to disable a component's backup by setting its Kubernetes CronJob schedule to `'0 0 1 1 1970'`. Kubernetes rejects this (`end of range (1970) above maximum (6)` — CronJob schedules have no year field), so the documented procedure does not work.

The Helm chart now provides real per-component `enabled` toggles (default `true`). This PR updates the docs to use them.

## Changes

In `setup/data-management/backup_restore/backup_enable.adoc` and `kubernetes_backup.adoc` (English source), the "Disable scheduled backups" sections now use:

- StackGraph: `backup.stackGraph.scheduled.enabled: false`
- Settings/configuration: `backup.configuration.scheduled.enabled: false`
- Victoria Metrics: `victoria-metrics-{0,1}.backup.enabled: false` (per instance)
- ClickHouse: `clickhouse.backup.enabled: false`
- Elasticsearch: `backup.elasticsearch.scheduled.enabled: false`

Also updated the Settings backup NOTE: settings backups are enabled by default but now controlled independently via `backup.configuration.scheduled.enabled`, and disabling every backup (including settings) stops the S3 Proxy from being deployed.

## Notes

- Targets `staging` — documents forthcoming-release chart behavior.
- Only the English source is edited; translations are left for the translation workflow.

Depends on chart change: StackVista/helm-charts-internal#105