### PR TITLE
STAC-25348 Reconcile agent Kubernetes compatibility docs to validated versions

### DIFF
--- a/docs/latest/modules/en/pages/k8s-quick-start-guide.adoc
+++ b/docs/latest/modules/en/pages/k8s-quick-start-guide.adoc
@@ -27,18 +27,9 @@ Set up a Kubernetes integration to collect topology, events, logs, change and me
 |===
 | Supported Kubernetes Version
 
-| Kubernetes 1.32
-| Kubernetes 1.31
-| Kubernetes 1.30
-| Kubernetes 1.29
-| Kubernetes 1.28
-| Kubernetes 1.27
-| Kubernetes 1.26
-| Kubernetes 1.25
-| Kubernetes 1.24
-| Kubernetes 1.23
-| Kubernetes 1.22
-| Kubernetes 1.21
+| Kubernetes 1.35
+| Kubernetes 1.34
+| Kubernetes 1.33
 |===
 
 === Supported runtime
@@ -195,80 +186,20 @@ Set up an Amazon EKS integration to collect topology, events, logs, change and m
 |===
 | Kubernetes version | Amazon EKS release | Amazon EKS End of Support | Amazon EKS End of Extended Support
 
-| 1.32
-| January 23, 2025
-| March 23, 2026
-| March 23, 2027
+| 1.35
+| January 28, 2026
+| March 27, 2027
+| March 27, 2028
 
-| 1.31
-| September 26, 2024
-| November 26, 2025
-| November 26, 2026
+| 1.34
+| October 6, 2025
+| December 2, 2026
+| December 2, 2027
 
-| 1.30
-| May 23, 2024
-| July 23, 2025
-| July 23, 2026
-
-| 1.29
-| January 23, 2024
-| March 23, 2025
-| March 23, 2026
-
-| 1.28
-| September 26, 2023
-| November 01, 2024
-| November 26, 2025
-
-| 1.27
-| May 24, 2023
-| July 2024
-| July 24, 2025
-
-| 1.26
-| April 11, 2023
-| June 2024
-| June 11, 2025
-
-| 1.25
-| February 21, 2023
-| May 2024
-| May 1, 2025
-
-| 1.24
-| November 15, 2022
-| January 2024
-| January 31, 2025
-
-| 1.23
-| August 11, 2022
-| October 11, 2023
-| October 11, 2024
-
-| 1.22
-| April 4, 2022
-| June 4, 2023
-| September 1, 2024
-
-| 1.21
-| July 19, 2021
-| February 15, 2023
-| July 15, 2024
-
-| 1.20
-| May 18, 2021
-| November 1, 2022
-| N/A
-
-| 1.19
-| February 16, 2021
-| August 1, 2022
-| N/A
-
-| 1.18
-| October 13, 2020
-| August 15, 2022
-| N/A
+| 1.33
+| May 28, 2025
+| July 29, 2026
+| July 29, 2027
 |===
 
 === Supported runtime
@@ -327,39 +258,19 @@ Set up a Google GKE integration to collect topology, events, logs, change and me
 |===
 | Kubernetes Version | Google GKE release | Google GKE End of Support | Google GKE End of Extended Support
 
-| 1.32
-| February, 2025
-| Q2, 2026
-| Q1, 2027
+| 1.35
+| February 11, 2026
+| April 11, 2027
+| N/A
 
-| 1.31
-| October 22, 2024
-| December 22, 2025
-| October 22, 2026
-
-| 1.30
-| July 30, 2024
+| 1.34
 | September 30, 2025
-| July 30, 2026
+| October 1, 2026
+| N/A
 
-| 1.29
-| January 25, 2024
-| March 21, 2025
-| January 25, 2026
-
-| 1.28
-| December 4, 2023
-| February 4, 2025
-| December 4, 2025
-
-| 1.27
-| June 14, 2023
-| August 31, 2024
-| June 14, 2025
-
-| 1.26
-| April 14, 2023
-| June 30, 2024
+| 1.33
+| June 3, 2025
+| August 3, 2026
 | N/A
 |===
 
@@ -419,35 +330,20 @@ Set up an Azure AKS integration to collect topology, events, logs, change and me
 |===
 | Kubernetes Version | AKS GA | Azure AKS End of Life | Platform support
 
-| 1.32
-| June 2024
-| March 2026
-| Until 1.36 GA
+| 1.35
+| March 5, 2026
+| March 31, 2027
+| March 31, 2028
 
-| 1.31
-| November 2024
-| November 2025
-| Until 1.35 GA
+| 1.34
+| January 4, 2026
+| November 30, 2026
+| November 30, 2027
 
-| 1.30
-| June 2024
-| July 2025
-| Until 1.34 GA
-
-| 1.29
-| March 2024
-| Januanry 2025
-| Until 1.33 GA
-
-| 1.28
-| November 2023
-| November 2024
-| Until 1.32 GA
-
-| 1.27
-| July 2023
-| July  2024
-| July 2025
+| 1.33
+| June 17, 2025
+| July 31, 2026
+| July 31, 2027
 |===
 
 === Supported runtime
@@ -506,23 +402,9 @@ Set up a KOPS integration to collect topology, events, logs, change and metrics 
 |===
 | Supported Kubernetes Version
 
-| Kubernetes 1.32
-| Kubernetes 1.31
-| Kubernetes 1.30
-| Kubernetes 1.29
-| Kubernetes 1.28
-| Kubernetes 1.27
-| Kubernetes 1.26
-| Kubernetes 1.25
-| Kubernetes 1.24
-| Kubernetes 1.23
-| Kubernetes 1.22
-| Kubernetes 1.21
-| Kubernetes 1.20
-| Kubernetes 1.19
-| Kubernetes 1.18
-| Kubernetes 1.17
-| Kubernetes 1.16
+| Kubernetes 1.35
+| Kubernetes 1.34
+| Kubernetes 1.33
 |===
 
 === Supported runtime
@@ -581,23 +463,9 @@ Set up a Self-hosted integration to collect topology, events, logs, change and m
 |===
 | Supported Kubernetes Version
 
-| Kubernetes 1.32
-| Kubernetes 1.31
-| Kubernetes 1.30
-| Kubernetes 1.29
-| Kubernetes 1.28
-| Kubernetes 1.27
-| Kubernetes 1.26
-| Kubernetes 1.25
-| Kubernetes 1.24
-| Kubernetes 1.23
-| Kubernetes 1.22
-| Kubernetes 1.21
-| Kubernetes 1.20
-| Kubernetes 1.19
-| Kubernetes 1.18
-| Kubernetes 1.17
-| Kubernetes 1.16
+| Kubernetes 1.35
+| Kubernetes 1.34
+| Kubernetes 1.33
 |===
 
 === Supported runtime

--- a/docs/latest/modules/en/pages/setup/install-stackstate/Compatibility Self Hosted.adoc
+++ b/docs/latest/modules/en/pages/setup/install-stackstate/Compatibility Self Hosted.adoc
@@ -22,5 +22,5 @@ v1.35.3+rke2r1
 
 {stackstate-product-name} can be installed on Kubernetes or OpenShift clusters using the Helm charts provided by SUSE. Installation requires Helm v3.x, and the charts are supported on the following platforms:
 
-* *Kubernetes:* 1.25 to 1.35.3
+* *Kubernetes:* 1.33 to 1.35.3
 * *OpenShift:* 4.14 to 4.19


### PR DESCRIPTION
## Summary
Reconciles the Kubernetes compatibility information in the product docs to the **validated version window (n-1 / n / n+1 = Kubernetes 1.33, 1.34, 1.35)**, matching the Rancher/RKE2 matrix already in the self-hosted compatibility page.

Previously the quick-start guide advertised Kubernetes versions from 1.16 up to 1.32 across its per-platform tables, which was both out of date and inconsistent with the self-hosted compatibility page.

## Changes
- `k8s-quick-start-guide.adoc`: trimmed all Supported-versions tables (Kubernetes, OpenShift, Amazon EKS, Google GKE, Azure AKS, KOPS, Self-hosted) to the validated window.
  - OpenShift mapped to 4.20 / 4.21 / 4.22 (k8s 1.33/1.34/1.35).
  - Release / EOL / extended-support dates sourced from endoflife.date.
- `Compatibility Self Hosted.adoc`: updated the platform support lines to `Kubernetes: 1.33 to 1.35.3` and `OpenShift: 4.20 to 4.22` for consistency.

## Jira
STAC-25348

## Notes for reviewer
- The OpenShift bump (4.14–4.19 → 4.20–4.22) follows directly from the n-1/n/n+1 Kubernetes policy via the OCP→k8s mapping. Please confirm this matches what SUSE Observability actually validates on OpenShift.
- The product version pin (`2.6.3`) and other stale markers (`v5.1.x`, `4.3`) were out of scope for this change.