### PR TITLE
STAC-25303: document Azure container pre-creation requirement

### DIFF
--- a/docs/latest/modules/en/pages/setup/data-management/backup_restore/backup_enable.adoc
+++ b/docs/latest/modules/en/pages/setup/data-management/backup_restore/backup_enable.adoc
@@ -212,6 +212,16 @@ The IAM user identified by `AWS_ACCESS_KEY` and `AWS_SECRET_KEY` must be configu
 
 === Azure Blob Storage
 
+[IMPORTANT]
+====
+**The storage account must support Blob storage, and the containers must already exist.**
+
+* Use a general-purpose v2 (`StorageV2`) or premium block blob (`BlockBlobStorage`) storage account. A premium file shares (`FileStorage`) account has no Blob endpoint and cannot be used. Pointing {stackstate-product-name} at one fails with `java.net.UnknownHostException: <accountName>.blob.core.windows.net` in the S3 Proxy logs.
+* **Create the BLOB containers before enabling backups.** {stackstate-product-name} does not create them for you. If a container is missing, the backup job fails with `api error NoSuchBucket: The specified bucket does not exist`.
+
+Container names must follow the https://learn.microsoft.com/en-us/rest/api/storageservices/naming-and-referencing-containers--blobs--and-metadata[Azure naming rules (learn.microsoft.com)]: 3-63 characters, lowercase letters, numbers and single hyphens.
+====
+
 ==== Using separate containers
 
 To enable backups to separate Azure Blob Storage containers (one per datastore), add the following YAML fragment to the Helm `values.yaml` file used to install {stackstate-product-name}:
@@ -250,6 +260,18 @@ Replace the following values:
 * `AZURE_STORAGE_ACCOUNT_KEY` - the https://learn.microsoft.com/en-us/azure/storage/common/storage-account-keys-manage?tabs=azure-portal[Azure storage account key (learn.microsoft.com)] where the backups should be stored.
 
 The StackGraph, Elasticsearch, Victoria Metrics, and ClickHouse backups are stored in BLOB containers called `sts-stackgraph-backup`, `sts-configuration-backup`, `sts-elasticsearch-backup`, `sts-victoria-metrics-backup`, `sts-clickhouse-backup` respectively. These names can be changed by setting the Helm values `backup.stackGraph.bucketName`, `backup.elasticsearch.bucketName`, `victoria-metrics-0.backup.bucketName`, `victoria-metrics-1.backup.bucketName` and `clickhouse.backup.bucketName` respectively.
+
+**All five containers must be created in the storage account before backups run**, whether you keep the default names or override them. For example, using the Azure CLI:
+
+[,bash]
+----
+for c in sts-stackgraph-backup sts-configuration-backup sts-elasticsearch-backup \
+         sts-victoria-metrics-backup sts-clickhouse-backup; do
+  az storage container create --name "$c" \
+    --account-name "$AZURE_STORAGE_ACCOUNT_NAME" \
+    --account-key "$AZURE_STORAGE_ACCOUNT_KEY"
+done
+----
 
 ==== Using a single container with prefixes
 
@@ -300,6 +322,15 @@ clickhouse:
 Replace the following values:
 * `YOUR_ACCESS_KEY` and `YOUR_SECRET_KEY` are the credentials that will be used to secure the S3 Proxy instance. The automatic backup jobs and the restore jobs use these to authenticate. They're also required if you want to manually access the S3 Proxy instance.
 * `CONTAINER` with your Azure Blob Storage container name. The backups for different datastores will be organized using the configured `s3Prefix` values. The same `AZURE_STORAGE_ACCOUNT_NAME` and `AZURE_STORAGE_ACCOUNT_KEY` values from the previous section apply here.
+
+**The container must be created before backups run** - {stackstate-product-name} does not create it. Only one container is needed in this layout, because the datastores are separated by prefix:
+
+[,bash]
+----
+az storage container create --name "$CONTAINER" \
+  --account-name "$AZURE_STORAGE_ACCOUNT_NAME" \
+  --account-key "$AZURE_STORAGE_ACCOUNT_KEY"
+----
 
 === Kubernetes Persistent Volume
 

--- a/docs/latest/modules/en/pages/setup/data-management/backup_restore/backup_enable.adoc
+++ b/docs/latest/modules/en/pages/setup/data-management/backup_restore/backup_enable.adoc
@@ -219,7 +219,7 @@ The IAM user identified by `AWS_ACCESS_KEY` and `AWS_SECRET_KEY` must be configu
 * Use a general-purpose v2 (`StorageV2`) or premium block blob (`BlockBlobStorage`) storage account. A premium file shares (`FileStorage`) account has no Blob endpoint and cannot be used. Pointing {stackstate-product-name} at one fails with `java.net.UnknownHostException: <accountName>.blob.core.windows.net` in the S3 Proxy logs.
 * **Create the BLOB containers before enabling backups.** {stackstate-product-name} does not create them for you. If a container is missing, the backup job fails with `api error NoSuchBucket: The specified bucket does not exist`.
 
-Container names must follow the https://learn.microsoft.com/en-us/rest/api/storageservices/naming-and-referencing-containers--blobs--and-metadata[Azure naming rules (learn.microsoft.com)]: 3-63 characters, lowercase letters, numbers and single hyphens.
+Container names must follow the link:https://learn.microsoft.com/en-us/rest/api/storageservices/naming-and-referencing-containers--blobs--and-metadata[Azure naming rules (learn.microsoft.com)]: 3-63 characters, lowercase letters, numbers and single hyphens.
 ====
 
 ==== Using separate containers


### PR DESCRIPTION
## Problem

Enabling Azure Blob backups against a **fresh storage account** fails. Nothing in SUSE Observability creates the BLOB containers, so the first backup job dies with:

```
api error NoSuchBucket: The specified bucket does not exist
```

The docs currently mention the container names only descriptively — *"backups are stored in BLOB containers called `sts-stackgraph-backup`, ..."* — which reads as a statement of fact, not a prerequisite. `job-backup-init` does not help: it runs `configure-backup.sh`, which only registers the Elasticsearch snapshot repository.

Any customer pointing at a new storage account hits this on their first backup.

## Changes

Adds an `IMPORTANT` admonition to the **Azure Blob Storage** section, plus `az storage container create` examples for both documented layouts:

- **Containers must exist before backups run.** Examples for the separate-containers layout (all five) and the single-container-with-prefixes layout (one).
- **The account must expose a Blob endpoint.** A premium file shares (`FileStorage`) account has no Blob endpoint and cannot be used — it fails with `java.net.UnknownHostException: <accountName>.blob.core.windows.net`, which gives no clue as to the real cause. Recommends `StorageV2` / `BlockBlobStorage`.
- **Azure container naming rules**, since deployment-derived names can approach the 63-character limit.

English source page only; translations not touched.

## How this was found

Manual QA of StackGraph backup/restore v2 against Azure Blob (STAC-25303). Both failure modes were hit for real:

1. A `FileStorage` account produced `UnknownHostException` with no indication the account kind was wrong.
2. Once on a `StorageV2` account, the first backup still failed with `NoSuchBucket` until the container was created by hand.

After pre-creating the container, backup and restore both passed end to end, including a data-correctness check (mutate → restore → state rolled back to the exact pre-backup fingerprint).

## Note

The AWS S3 section already sets a precedent for this kind of callout — it explicitly documents that SSE-KMS is unsupported and quotes the resulting error. The Azure section had no equivalent.

Related: StackVista/stackstate-backup-cli#32 (unreleased `stackgraph-v2` CLI), rancher/stackstate-product-docs#360 (v2 backup/restore docs).