### PR TITLE
Roll the Kubernetes compatibility window to 1.34-1.36

### DIFF
--- a/docs/latest/modules/en/pages/k8s-quick-start-guide.adoc
+++ b/docs/latest/modules/en/pages/k8s-quick-start-guide.adoc
@@ -27,9 +27,9 @@ Set up a Kubernetes integration to collect topology, events, logs, change and me
 |===
 | Supported Kubernetes Version
 
+| Kubernetes 1.36
 | Kubernetes 1.35
 | Kubernetes 1.34
-| Kubernetes 1.33
 |===
 
 === Supported runtime
@@ -186,6 +186,11 @@ Set up an Amazon EKS integration to collect topology, events, logs, change and m
 |===
 | Kubernetes version | Amazon EKS release | Amazon EKS End of Support | Amazon EKS End of Extended Support
 
+| 1.36
+| June 2, 2026
+| August 2, 2027
+| August 2, 2028
+
 | 1.35
 | January 28, 2026
 | March 27, 2027
@@ -195,11 +200,6 @@ Set up an Amazon EKS integration to collect topology, events, logs, change and m
 | October 6, 2025
 | December 2, 2026
 | December 2, 2027
-
-| 1.33
-| May 28, 2025
-| July 29, 2026
-| July 29, 2027
 |===
 
 === Supported runtime
@@ -258,6 +258,11 @@ Set up a Google GKE integration to collect topology, events, logs, change and me
 |===
 | Kubernetes Version | Google GKE release | Google GKE End of Support | Google GKE End of Extended Support
 
+| 1.36
+| June 9, 2026
+| August 9, 2027
+| N/A
+
 | 1.35
 | February 11, 2026
 | April 11, 2027
@@ -266,11 +271,6 @@ Set up a Google GKE integration to collect topology, events, logs, change and me
 | 1.34
 | September 30, 2025
 | October 1, 2026
-| N/A
-
-| 1.33
-| June 3, 2025
-| August 3, 2026
 | N/A
 |===
 
@@ -330,6 +330,11 @@ Set up an Azure AKS integration to collect topology, events, logs, change and me
 |===
 | Kubernetes Version | AKS GA | Azure AKS End of Life | Platform support
 
+| 1.36
+| June 30, 2026
+| June 30, 2027
+| June 30, 2028
+
 | 1.35
 | March 5, 2026
 | March 31, 2027
@@ -339,11 +344,6 @@ Set up an Azure AKS integration to collect topology, events, logs, change and me
 | January 4, 2026
 | November 30, 2026
 | November 30, 2027
-
-| 1.33
-| June 17, 2025
-| July 31, 2026
-| July 31, 2027
 |===
 
 === Supported runtime
@@ -402,9 +402,9 @@ Set up a KOPS integration to collect topology, events, logs, change and metrics 
 |===
 | Supported Kubernetes Version
 
+| Kubernetes 1.36
 | Kubernetes 1.35
 | Kubernetes 1.34
-| Kubernetes 1.33
 |===
 
 === Supported runtime
@@ -463,9 +463,9 @@ Set up a Self-hosted integration to collect topology, events, logs, change and m
 |===
 | Supported Kubernetes Version
 
+| Kubernetes 1.36
 | Kubernetes 1.35
 | Kubernetes 1.34
-| Kubernetes 1.33
 |===
 
 === Supported runtime

--- a/docs/latest/modules/en/pages/setup/install-stackstate/Compatibility Self Hosted.adoc
+++ b/docs/latest/modules/en/pages/setup/install-stackstate/Compatibility Self Hosted.adoc
@@ -8,19 +8,19 @@ The matrix below lists the compatible Rancher versions and their corresponding s
 |===
 | Rancher Version | RKE2 / Kubernetes Versions
 
-| 2.12.x
-| v1.33.10+rke2r1
-
 | 2.13.x
 | v1.34.6+rke2r1
 
 | 2.14.x
+| v1.35.3+rke2r1
+
+| 2.15.x
 a|
-v1.35.3+rke2r1
+v1.36.3+rke2r1
 
 |===
 
 {stackstate-product-name} can be installed on Kubernetes or OpenShift clusters using the Helm charts provided by SUSE. Installation requires Helm v3.x, and the charts are supported on the following platforms:
 
-* *Kubernetes:* 1.33 to 1.35.3
+* *Kubernetes:* 1.34 to 1.36.3
 * *OpenShift:* 4.14 to 4.19


### PR DESCRIPTION
Rancher v2.15.0 shipped 2026-07-30, adding Kubernetes 1.36 (default `v1.36.3+rke2r1`) and [removing 1.33](https://github.com/rancher/rancher/releases/tag/v2.15.0). Kubernetes 1.33 has also left standard support on every hosted platform we document

| | Before | After |
|---|---|---|
| Rancher → RKE2 | 2.12.x/1.33.10, 2.13.x/1.34.6, 2.14.x/1.35.3 | 2.13.x/1.34.6, 2.14.x/1.35.3, **2.15.x/1.36.3** |
| Helm platform line | Kubernetes 1.33 to 1.35.3 | **1.34 to 1.36.3** |
| Quick-start tables | 1.33/1.34/1.35 | **1.34/1.35/1.36** |

Release and end-of-support dates from endoflife.date. OpenShift ranges left unchanged, as in the previous pass.

**Known gap, not fixed here:** the six translations (de/es/fr/ja/pt/zh) still publish Rancher 2.11.x–2.13.x all mapped to `v1.30.11+rke2r1` and "Kubernetes 1.25 to 1.33". All seven languages are served live, so they now contradict English by three minor versions.