### PR TITLE
[STAC-24875] docs: configure trust stores from an existing secret

### DIFF
--- a/docs/latest/modules/en/pages/setup/security/authentication/ldap.adoc
+++ b/docs/latest/modules/en/pages/setup/security/authentication/ldap.adoc
@@ -72,6 +72,7 @@ Follow the steps below to configure SUSE Observability to authenticate using LDA
  ** *sslType* - Optional. The type of LDAP secure connection `ssl` or `startTls`. Omit if plain LDAP connection is used.
  ** *trustCertificates* - Optional, certificate file for SSL. Formats PEM, DER and PKCS7 are supported.
  ** *trustStore* - Optional, Java trust store file for SSL. If both `trustCertificates` and `trustStore` are specified, `trustCertificatesPath` takes precedence.
+ ** *trustCertificatesFromExternalSecret* and *trustStoreFromExternalSecret* - Optional, read the certificates from an existing secret instead of from a file, which keeps them out of the size-limited Helm release secret. See *Using an existing secret* below.
  ** *bind* - Optional, used to authenticate SUSE Observability to LDAP server if the LDAP server doesn't support anonymous LDAP searches.
  ** *userQuery parameters and groupQuery parameters* - The set of parameters inside correspond to the base dn of your LDAP where users and groups can be found. The first one is used for authenticating users in SUSE Observability, while the second is used for retrieving the group of that user to determine if the user is an Administrator, Power User or a Guest.
  ** *usernameKey* - The name of the attribute that stores the username, value is matched against the username provided on the login screen.
@@ -121,6 +122,42 @@ helm upgrade \
 suse-observability \
 suse-observability/suse-observability
 ----
+
+*Using an existing secret*
+
+[NOTE]
+====
+Configuring the certificates from an existing secret is available starting from version `2.10.4`. For earlier versions, use the `--set-file` arguments above.
+====
+
+Certificates and trust stores passed with `--set-file` are stored in the Helm release secret, which is subject to a 1MB size limit. A large trust store can therefore make `helm upgrade` fail. To avoid that, create a secret up front and refer to it from `authentication.yaml`:
+
+[,bash]
+----
+kubectl create secret generic ldap-truststore \
+  --namespace suse-observability \
+  --from-file=cacerts=./ldap-cacerts \
+  --from-file=certificates.pem=./ldap-certificate.pem
+----
+
+[,yaml]
+----
+stackstate:
+  authentication:
+    ldap:
+      ssl:
+        type: ssl
+        trustStoreFromExternalSecret:
+          name: ldap-truststore
+          key: cacerts
+        trustCertificatesFromExternalSecret:
+          name: ldap-truststore
+          key: certificates.pem
+----
+
+The two are configured independently, so you can set only the one you need, and they may live in different secrets. When set, they take precedence over `trustStore` and `trustCertificates`. Remove the `--set-file` arguments once you have migrated, since any remaining inline value still counts against the release secret size limit.
+
+For more on the size limit and how to check your current release secret, see xref:/use/security/self-signed-certificates.adoc#_trust_stores_and_the_helm_release_secret_size_limit[Trust stores and the Helm release secret size limit].
 
 [NOTE]
 ====

--- a/docs/latest/modules/en/pages/use/security/self-signed-certificates.adoc
+++ b/docs/latest/modules/en/pages/use/security/self-signed-certificates.adoc
@@ -256,7 +256,84 @@ keytool -import -keystore custom_cacerts -alias <a-name-for-the-certificate>  -f
 
 === Use a custom trust store
 
-The trust store and the password can be specified as values. The trust store can only be specified from the helm command line as it's a file. The password value is specified in the same way in the example, but it can also be provided via a `values.yaml` file.
+[NOTE]
+====
+Configuring the trust store from an existing secret is available starting from version `2.10.4`. For earlier versions, use the Helm values described in xref:/use/security/self-signed-certificates.adoc#_specify_the_trust_store_as_a_helm_value[Specify the trust store as a Helm value].
+====
+
+Create a Kubernetes secret holding the trust store and its password, then refer to that secret from your values. This keeps the trust store out of the Helm release secret, which is subject to a 1MB size limit. See xref:/use/security/self-signed-certificates.adoc#_trust_stores_and_the_helm_release_secret_size_limit[Trust stores and the Helm release secret size limit] for why that matters.
+
+[,bash]
+----
+kubectl create secret generic java-truststore \
+  --namespace suse-observability \
+  --from-file=java-cacerts=custom_cacerts \
+  --from-literal=java-cacerts-password=changeit
+----
+
+Add the secret to your `values.yaml`:
+
+[,yaml]
+----
+stackstate:
+  java:
+    trustStoreFromExternalSecret:
+      name: java-truststore
+      # The key holding the trust store file. Defaults to java-cacerts.
+      key: java-cacerts
+      # Optional. When omitted, stackstate.java.trustStorePassword is used instead.
+      passwordKey: java-cacerts-password
+----
+
+Then upgrade as usual, with no extra command line arguments needed:
+
+[,bash]
+----
+helm upgrade \
+  --install \
+  --namespace suse-observability \
+  --values values.yaml \
+suse-observability \
+suse-observability/suse-observability
+----
+
+[NOTE]
+====
+Changing the secret afterwards does not restart the SUSE Observability pods. After rotating a trust store, restart the workloads so they pick up the new file:
+
+[,bash]
+----
+kubectl rollout restart deployment,statefulset --namespace suse-observability
+----
+====
+
+[#_trust_stores_and_the_helm_release_secret_size_limit]
+=== Trust stores and the Helm release secret size limit
+
+Helm stores every value you supply in a release secret, and that secret is subject to the 1MB limit of the underlying object in the cluster. A trust store supplied as a Helm value counts against that limit twice, once as the value itself and once as the secret SUSE Observability renders from it. Trust stores are binary, so they do not compress. A trust store of a few hundred KB is therefore enough on its own to make `helm upgrade` fail with an error about the release secret being too large.
+
+To check the size of your current release secret and see which values dominate it:
+
+[,bash]
+----
+kubectl get secret --namespace suse-observability \
+  -l "owner=helm,name=suse-observability" \
+  -o jsonpath='{.items[-1:].data.release}' | \
+  base64 -d | base64 -d | gunzip | \
+  jq '.config.stackstate.java | to_entries | map({key: .key, size: (.value | tostring | length)}) | sort_by(.size) | reverse'
+----
+
+If `trustStoreBase64Encoded` or `trustStore` shows up as hundreds of thousands of bytes, move the trust store into a secret as described above.
+
+[IMPORTANT]
+====
+When migrating, remove `stackstate.java.trustStore` and `stackstate.java.trustStoreBase64Encoded` from your values. `trustStoreFromExternalSecret` takes precedence, so the trust store will be mounted from the secret either way, but any inline value you leave behind still counts against the release secret size limit.
+====
+
+[#_specify_the_trust_store_as_a_helm_value]
+=== Specify the trust store as a Helm value
+
+The trust store and the password can also be specified directly as values. This remains supported, but is subject to the size limit described above, so prefer an existing secret. The trust store can only be specified from the helm command line as it's a file. The password value is specified in the same way in the example, but it can also be provided via a `values.yaml` file.
 
 [,bash]
 ----
@@ -276,7 +353,7 @@ suse-observability/suse-observability
 
 * The first run of the helm upgrade command will result in pods restarting, which may cause a short interruption of availability.
 * Include these arguments on every `helm upgrade` run.
-* The password and trust store are stored as a Kubernetes secret.
+* The password and trust store are stored as a Kubernetes secret, and are also kept in the Helm release secret, which is subject to the size limit described above.
 ====
 
 


### PR DESCRIPTION
## Configure trust stores from an existing secret

A trust store supplied as a Helm value is stored in the Helm release secret, which is subject to the 1MB limit of the underlying object in the cluster. It is counted against that limit twice, once as the value itself and once as the secret SUSE Observability renders from it. Trust stores are binary and do not compress, so a few hundred KB is enough on its own to make `helm upgrade` fail. A customer hit exactly this when upgrading to 2.10.

The chart now supports reading trust stores from a user-managed secret, the same pattern already used for passwords, licenses and API keys. These pages document it.

Chart side: StackVista/helm-charts-internal#153

### Reviewing this PR

This branch was cut from `main`, so the commit list also contains the commits `main` has that `staging` does not. Only two files are actually changed by this work:

- `docs/latest/modules/en/pages/use/security/self-signed-certificates.adoc`
- `docs/latest/modules/en/pages/setup/security/authentication/ldap.adoc`

Compared against `main` the change is 1 commit, 2 files, +116 −2.

### What changed

**`use/security/self-signed-certificates.adoc`**

- "Use a custom trust store" now leads with creating a secret via `kubectl create secret generic` and referencing it with `stackstate.java.trustStoreFromExternalSecret` in `values.yaml`. This also removes the need to repeat `--set-file` on every `helm upgrade`.
- New section "Trust stores and the Helm release secret size limit" explaining the limit, with a command to check whether an existing installation is affected and which values dominate its release secret.
- The previous `--set-file` instructions are preserved under a new heading, "Specify the trust store as a Helm value", and marked as subject to the size limit. The Base64 method is unchanged and still documented.
- Added a note that changing the secret does not restart pods, with the `kubectl rollout restart` command needed after rotating a trust store.

**`setup/security/authentication/ldap.adoc`**

- New "Using an existing secret" subsection covering `trustStoreFromExternalSecret` and `trustCertificatesFromExternalSecret`, noting that the two are configured independently and may live in different secrets.
- Both options added to the LDAP settings list, with a cross-reference to the size limit section.

### Migration guidance

Both pages state that the inline values must be **removed**, not merely supplemented. The external secret takes precedence, so the trust store is mounted correctly either way, but any leftover inline value still counts against the release secret size limit. Without this, someone could follow the new instructions, see the trust store working, and still be unable to upgrade.

### Version gating

The new values are only available from chart version `2.10.4`, so both pages carry a note saying so, following the existing convention used for `global.suseObservability` and version `2.8.0`.

Two things to confirm before this reaches published docs:

- If the chart change lands in a release other than 2.10.4, the version in both notes needs updating.
- Helm does not error on unknown values, so a user on an older chart who follows these instructions gets no warning, no mounted trust store, and puzzling TLS failures. The version note is what prevents that, which is why the number matters.

### Test plan

- [x] `make ci-pr-link-check` produces exactly the same warning and error counts as `main` (132 WARN, 152 ERROR), so no new issues are introduced. Note this target already exits non-zero on `main`, so that failure is pre-existing.
- [x] Both pages render, and the new anchors `_trust_stores_and_the_helm_release_secret_size_limit` and `_specify_the_trust_store_as_a_helm_value` resolve, including the cross-page xref from the LDAP page.
- [x] Only `en/` is touched, since translations are handled by a separate pipeline.

Relates to [STAC-24875](https://stackstate.atlassian.net/browse/STAC-24875)
