### PR TITLE
STAC-25601: correct securityContext and required-privileges claims

### DIFF
--- a/docs/latest/modules/en/pages/k8s-quick-start-guide.adoc
+++ b/docs/latest/modules/en/pages/k8s-quick-start-guide.adoc
@@ -185,6 +185,31 @@ To get data from a Kubernetes cluster into {stackstate-product-name}, follow the
 . Deploy the {stackstate-product-name} Agent, Cluster Agent, Checks Agent and kube-state-metrics on your Cluster using the helm command provided in the {stackstate-product-name} UI after you have installed the StackPack. The default namespace for the agent is `suse-observability-agent`. The UI instructions remove a previous agent release from `suse-observability` before installing into the new namespace, `suse-observability-agent`, to avoid running duplicate agents.
  ** Once the Agents have been deployed, they will begin collecting data and push this to {stackstate-product-name}
 
+[#openshift-optional-components]
+=== Security context for optional components on OpenShift
+
+The components installed above need no security context changes. Two optional components do, because they run images that declare no `USER`: the chart gives them an explicit `runAsUser` so that they can run as a non-root user on plain Kubernetes. OpenShift instead assigns a UID from the project's own range through the `restricted-v2` SCC, and rejects a pod that asks for a UID outside it. Neither component is covered by the node agent's SCC.
+
+If you enable either of them on OpenShift, clear the UID so that OpenShift can assign one:
+
+[,yaml]
+----
+# Only needed if you enable the process agent's remote pod correlation cache
+remoteKubeCache:
+  containerSecurityContext:
+    runAsUser: null
+
+# Only needed if you enable httpHeaderInjectorWebhook
+httpHeaderInjectorWebhook:
+  containerSecurityContext:
+    runAsUser: null
+----
+
+[NOTE]
+====
+The UID has to be set to `null`. Replacing the whole `containerSecurityContext` with `{}` does not work, because Helm merges it with the chart's default and the UID survives.
+====
+
 [#amazon-eks]
 == Amazon EKS
 

--- a/docs/latest/modules/en/pages/k8s-suse-rancher-prime.adoc
+++ b/docs/latest/modules/en/pages/k8s-suse-rancher-prime.adoc
@@ -178,7 +178,6 @@ A few optional init containers fix up data volume ownership by running `chown` a
 * `clickhouse.volumePermissions.enabled`
 * `kafka.volumePermissions.enabled`
 * `zookeeper.volumePermissions.enabled`
-* `hbase.hdfs.volumePermissions.enabled` together with `hbase.hdfs.volumePermissions.securityContext.enabled`
 
 [NOTE]
 ====

--- a/docs/latest/modules/en/pages/k8s-suse-rancher-prime.adoc
+++ b/docs/latest/modules/en/pages/k8s-suse-rancher-prime.adoc
@@ -1,6 +1,6 @@
 = {stackstate-product-name}
 :page-languages: [en, de, es, fr, ja, pt, zh]
-:revdate: 2026-03-26
+:revdate: 2026-08-20
 :page-revdate: {revdate}
 :description: {stackstate-product-name}
 
@@ -119,33 +119,63 @@ For information on installing the {stackstate-product-name} agent, see xref:k8s-
 
 == Required privileges
 
-The deployment of the {stackstate-product-name} agent requires the following system privileges:
+Two of the {stackstate-product-name} Agent workloads need privileges that the restricted Pod Security Standard does not allow. The other Agent workloads — the cluster agent, the checks agent, the Kubernetes RBAC agent, the HTTP header injector and the OpenTelemetry components — need none of them.
+
+=== Node agent
+
+The node agent is a DaemonSet running the node agent and process agent containers. It requires the following system privileges:
 
 . `hostPID: true`: This privilege is required to associate process identifiers (PIDs) with their corresponding control groups (cgroups). This association is essential for accurately mapping processes to their respective containers.
 . `hostNetwork: true` (Optional): By default, the node agent runs with `hostNetwork: true` to facilitate scraping of open metrics data from all configured pods on the node without requiring additional network policies. If disabled, appropriate network policies must be defined to ensure the agent can access the necessary endpoints.
-. `securityContext.privileged: true`: This elevated privilege is required for several critical functions. Primarily, it permits the agent to inject eBPF (extended Berkeley Packet Filter) programs into each network namespace for monitoring purposes. It is also necessary for reading the connection tracking (conntrack) tables across all network namespaces. While this list is not exhaustive, future development aims to replace this broad privilege with more granular Linux capabilities where feasible.
+. `securityContext.privileged: true` on the process agent container: This elevated privilege is required for several critical functions. Primarily, it permits the agent to inject eBPF (extended Berkeley Packet Filter) programs into each network namespace for monitoring purposes. It is also necessary for reading the connection tracking (conntrack) tables across all network namespaces. While this list is not exhaustive, future development aims to replace this broad privilege with more granular Linux capabilities where feasible.
 
-Furthermore, the agent requires container runtime sockets to be mounted within its pod. This configuration is essential as it facilitates direct communication with the container runtime daemons, which is a prerequisite for scraping metrics and metadata from all containers on the host system.
+Furthermore, the node agent requires container runtime sockets to be mounted within its pod. This configuration is essential as it facilitates direct communication with the container runtime daemons, which is a prerequisite for scraping metrics and metadata from all containers on the host system.
 
-== Rancher-Restricted PSA Template
+=== Logs agent
 
-The `Rancher-restricted` configuration (link:https://ranchermanager.docs.rancher.com/how-to-guides/new-user-guides/authentication-permissions-and-global-configuration/psa-config-templates[Pod Security Admission (PSA) Configuration Templates]) is a highly restrictive setup that aligns with current best practices for securing pods.
+The logs agent, enabled with `logsAgent.enabled`, is a DaemonSet that collects container logs from the node filesystem. It mounts the host paths `/var/log` and `/var/lib/docker/containers`, and its container sets `securityContext.seLinuxOptions.type` to `spc_t` so that it can read those paths on SELinux-enforcing nodes. It does not need `hostPID`, `hostNetwork` or `privileged`.
 
-When running Rancher on a Kubernetes cluster that enforces a restrictive security policy by default, there are two ways to install the SUSE Observability Helm chart:
+[#_rancher_restricted_psa_template]
+== Restrictive Pod Security policies
 
-* *Exempt the entire chart namespace*, along with other link:https://ranchermanager.docs.rancher.com/how-to-guides/new-user-guides/authentication-permissions-and-global-configuration/psa-config-templates#exempting-required-rancher-namespaces[required Rancher namespaces].
-* *Disable the privileged Elasticsearch init container* by setting `elasticsearch.sysctlInitContainer.enabled` to `false`. This requires you to manually increase the link:https://www.elastic.co/docs/deploy-manage/deploy/self-managed/vm-max-map-count[virtual memory settings] (`vm.max_map_count`) on the nodes. See also xref:/setup/install-stackstate/kubernetes_openshift/required_permissions.adoc#_elasticsearch[Elasticsearch Required Permissions]. 
+This section applies to any cluster that enforces the link:https://kubernetes.io/docs/concepts/security/pod-security-standards/#restricted[restricted Pod Security Standard] by default, including:
 
-Since the SUSE Observability Agent must run in privileged mode, the recommended approach is to install it into a namespace that you plan to exempt from the restrictive policy.
+* The `Rancher-restricted` link:https://ranchermanager.docs.rancher.com/how-to-guides/new-user-guides/authentication-permissions-and-global-configuration/psa-config-templates[Pod Security Admission (PSA) Configuration Template].
+* RKE2 clusters hardened with the link:https://docs.rke2.io/security/hardening_guide[CIS profile], which enables `restricted` as the cluster-wide default.
 
-[NOTE]
-====
-All SUSE Observability Helm chart containers are configured with the following `securityContext` settings starting from version `v2.3.8` and onwards:
+Every container in the {stackstate-product-name} and {stackstate-product-name} Agent Helm charts sets the following `securityContext` values, so that no namespace exemption is needed for them:
 
 . `securityContext.capabilities.drop` is `["ALL"]`
 . `securityContext.seccompProfile.type` is `"RuntimeDefault"`
 . `securityContext.runAsNonRoot` is `true`
 . `securityContext.allowPrivilegeEscalation` is `false`
+
+=== Exceptions
+
+Three containers cannot satisfy the restricted profile.
+
+[cols="1,2,2"]
+|===
+|Container |Chart |What to do
+
+|Elasticsearch `configure-sysctl` init container
+|{stackstate-product-name}
+|Disable it with `elasticsearch.sysctlInitContainer.enabled: false` and raise `vm.max_map_count` on the nodes yourself. See xref:/setup/install-stackstate/kubernetes_openshift/required_permissions.adoc#_elasticsearch[Elasticsearch Required Permissions].
+
+|Node agent DaemonSet (`node-agent` and `process-agent` containers)
+|{stackstate-product-name} Agent
+|Install the Agent into a namespace that is exempt from the policy. See <<_node_agent,Node agent>>.
+
+|Logs agent DaemonSet (`logs-agent` container)
+|{stackstate-product-name} Agent
+|Install the Agent into a namespace that is exempt from the policy, or leave `logsAgent.enabled` at `false`. See <<_logs_agent,Logs agent>>.
+|===
+
+Because of the node agent, the recommended approach is to install the {stackstate-product-name} Agent into a namespace that you exempt from the restrictive policy, alongside the other link:https://ranchermanager.docs.rancher.com/how-to-guides/new-user-guides/authentication-permissions-and-global-configuration/psa-config-templates#exempting-required-rancher-namespaces[required Rancher namespaces]. The {stackstate-product-name} chart itself needs no exemption once the Elasticsearch init container is disabled.
+
+[NOTE]
+====
+The Agent chart's `all.fullPrivilegesMode.enabled` option is a debugging aid: it replaces the restricted `securityContext` on the agent containers with a privileged one. Leave it at `false` on any cluster that enforces a restrictive policy.
 ====
 
 == Single Sign On

--- a/docs/latest/modules/en/pages/k8s-suse-rancher-prime.adoc
+++ b/docs/latest/modules/en/pages/k8s-suse-rancher-prime.adoc
@@ -178,7 +178,7 @@ A few optional init containers fix up data volume ownership by running `chown` a
 * `clickhouse.volumePermissions.enabled`
 * `kafka.volumePermissions.enabled`
 * `zookeeper.volumePermissions.enabled`
-* `hbase.hdfs.volumePermissions.enabled` together with `hbase.hdfs.volumePermissions.securityContext.enabled`
+* `hbase.hdfs.volumePermissions.enabled`
 
 [NOTE]
 ====

--- a/docs/latest/modules/en/pages/k8s-suse-rancher-prime.adoc
+++ b/docs/latest/modules/en/pages/k8s-suse-rancher-prime.adoc
@@ -143,16 +143,18 @@ This section applies to any cluster that enforces the link:https://kubernetes.io
 * The `Rancher-restricted` link:https://ranchermanager.docs.rancher.com/how-to-guides/new-user-guides/authentication-permissions-and-global-configuration/psa-config-templates[Pod Security Admission (PSA) Configuration Template].
 * RKE2 clusters hardened with the link:https://docs.rke2.io/security/hardening_guide[CIS profile], which enables `restricted` as the cluster-wide default.
 
-Every container in the {stackstate-product-name} and {stackstate-product-name} Agent Helm charts sets the following `securityContext` values, so that no namespace exemption is needed for them:
+Apart from the <<_exceptions,exceptions>> below, every container in the {stackstate-product-name} and {stackstate-product-name} Agent Helm charts runs with the following `securityContext` settings in effect, so those containers need no namespace exemption:
 
 . `securityContext.capabilities.drop` is `["ALL"]`
 . `securityContext.seccompProfile.type` is `"RuntimeDefault"`
 . `securityContext.runAsNonRoot` is `true`
 . `securityContext.allowPrivilegeEscalation` is `false`
 
+Most containers set all four themselves. A few set only `capabilities.drop` and `allowPrivilegeEscalation`, which can only be set per container, and inherit `runAsNonRoot` and `seccompProfile` from their pod. The result is the same either way.
+
 === Exceptions
 
-Three containers cannot satisfy the restricted profile.
+Four containers, across three workloads, cannot satisfy the restricted profile.
 
 [cols="1,2,2"]
 |===
@@ -171,9 +173,9 @@ Three containers cannot satisfy the restricted profile.
 |Install the Agent into a namespace that is exempt from the policy, or leave `logsAgent.enabled` at `false`. See <<_logs_agent,Logs agent>>.
 |===
 
-Because of the node agent, the recommended approach is to install the {stackstate-product-name} Agent into a namespace that you exempt from the restrictive policy, alongside the other link:https://ranchermanager.docs.rancher.com/how-to-guides/new-user-guides/authentication-permissions-and-global-configuration/psa-config-templates#exempting-required-rancher-namespaces[required Rancher namespaces]. The {stackstate-product-name} chart itself needs no exemption once the Elasticsearch init container is disabled.
+Because of the node agent, the recommended approach is to install the {stackstate-product-name} Agent into a namespace that you exempt from the restrictive policy, alongside the other link:https://ranchermanager.docs.rancher.com/how-to-guides/new-user-guides/authentication-permissions-and-global-configuration/psa-config-templates#exempting-required-rancher-namespaces[required Rancher namespaces]. The {stackstate-product-name} chart itself needs no exemption once the Elasticsearch init container is disabled, as long as the optional volume permission init containers below stay disabled, which is the default.
 
-A few optional init containers fix up data volume ownership by running `chown` as root, so they cannot satisfy the restricted profile either. They are all disabled by default, and you only need to consider them if you switch one on to repair volume permissions:
+Those optional init containers fix up data volume ownership by running `chown` as root, so they cannot satisfy the restricted profile either. You only need to consider them if you switch one on to repair volume permissions, and doing so puts the {stackstate-product-name} namespace back in need of an exemption:
 
 * `clickhouse.volumePermissions.enabled`
 * `kafka.volumePermissions.enabled`

--- a/docs/latest/modules/en/pages/k8s-suse-rancher-prime.adoc
+++ b/docs/latest/modules/en/pages/k8s-suse-rancher-prime.adoc
@@ -178,6 +178,7 @@ A few optional init containers fix up data volume ownership by running `chown` a
 * `clickhouse.volumePermissions.enabled`
 * `kafka.volumePermissions.enabled`
 * `zookeeper.volumePermissions.enabled`
+* `hbase.hdfs.volumePermissions.enabled` together with `hbase.hdfs.volumePermissions.securityContext.enabled`
 
 [NOTE]
 ====

--- a/docs/latest/modules/en/pages/k8s-suse-rancher-prime.adoc
+++ b/docs/latest/modules/en/pages/k8s-suse-rancher-prime.adoc
@@ -173,6 +173,13 @@ Three containers cannot satisfy the restricted profile.
 
 Because of the node agent, the recommended approach is to install the {stackstate-product-name} Agent into a namespace that you exempt from the restrictive policy, alongside the other link:https://ranchermanager.docs.rancher.com/how-to-guides/new-user-guides/authentication-permissions-and-global-configuration/psa-config-templates#exempting-required-rancher-namespaces[required Rancher namespaces]. The {stackstate-product-name} chart itself needs no exemption once the Elasticsearch init container is disabled.
 
+A few optional init containers fix up data volume ownership by running `chown` as root, so they cannot satisfy the restricted profile either. They are all disabled by default, and you only need to consider them if you switch one on to repair volume permissions:
+
+* `clickhouse.volumePermissions.enabled`
+* `kafka.volumePermissions.enabled`
+* `zookeeper.volumePermissions.enabled`
+* `hbase.hdfs.volumePermissions.enabled` together with `hbase.hdfs.volumePermissions.securityContext.enabled`
+
 [NOTE]
 ====
 The Agent chart's `all.fullPrivilegesMode.enabled` option is a debugging aid: it replaces the restricted `securityContext` on the agent containers with a privileged one. Leave it at `false` on any cluster that enforces a restrictive policy.


### PR DESCRIPTION
The page claimed every chart container sets the restricted `securityContext`. It did not — the accompanying chart change in `helm-charts-internal` makes it true, and this documents what is left over.

- Attributes the host privileges to the **node agent** DaemonSet (and `privileged` to its `process-agent` container) instead of "the agent"; the cluster agent, checks agent, RBAC agent, header injector and OTel components need none of them.
- Documents the **logs agent**, which was missing entirely.
- Covers CIS-hardened RKE2 as well as the Rancher-restricted PSA template, since both default to `restricted`.
- Lists the three exempt containers in a table with the action for each.

Reviewer notes:

- The "starting from version `v2.3.8`" provenance is dropped. Complete coverage only holds from the chart release that carries the `helm-charts-internal` change, and I do not know that version number yet — please add it if you do.
- `== Rancher-Restricted PSA Template` became `== Restrictive Pod Security policies`. An explicit `[#_rancher_restricted_psa_template]` anchor keeps the old URL fragment working; `#_required_privileges` (linked from `k8s-suse-rancher-prime-agent-air-gapped.adoc`) is unchanged.
- Validated with `asciidoctor`: renders without warnings, all anchors and xrefs resolve. No local Antora build (no node in this checkout).

Tracking: https://stackstate.atlassian.net/browse/STAC-25601