### PR TITLE
[STAC-24731] Rename platform otel collector to otel-receiver

### DIFF
--- a/docs/latest/modules/de/pages/setup/install-stackstate/advanced-troubleshooting.adoc
+++ b/docs/latest/modules/de/pages/setup/install-stackstate/advanced-troubleshooting.adoc
@@ -63,7 +63,7 @@ Die SUSE Observability-Plattform erhält Daten, die vom Agenten und dem OpenTele
  ** `Receiver-NonSplit`:
   *** `<release-name>-suse-observability-receiver-*`: Alle Daten des SUSE Observability Agenten kommen hierher.
 * `OpenTelemetry Collector`: Stellt einen Endpunkt bereit, an den OpenTelemetry-Agenten OpenTelemetry-Daten senden können, und erzeugt Traces, Kennzahlen und Topologie basierend auf den gesendeten Daten.
- ** `suse-observability-otel-collector-0`: Ein einzelner Pod, der den OTEL-Collector implementiert
+ ** `suse-observability-otel-receiver-0`: Ein einzelner Pod, der den OTEL-Collector implementiert
 
 === Verarbeitung und Bereitstellung
 

--- a/docs/latest/modules/de/pages/setup/install-stackstate/kubernetes_openshift/ingress.adoc
+++ b/docs/latest/modules/de/pages/setup/install-stackstate/kubernetes_openshift/ingress.adoc
@@ -101,9 +101,9 @@ Dieser Schritt geht davon aus, dass xref:/setup/install-stackstate/kubernetes_op
 
 == Ingress-Regel für Open Telemetry konfigurieren
 
-Das {stackstate-product-name} Helm-Chart stellt einen `opentelemetry-collector` Dienst in seinen Werten bereit, wo ein dedizierter `ingress` erstellt werden kann. Dies ist standardmäßig deaktiviert. Der für `opentelemetry-collector` erforderliche Ingress muss das GRPC-Protokoll unterstützen. Beachten Sie, dass die Einrichtung des Controllers selbst und der Zertifikate über den Rahmen dieses Dokuments hinausgeht.
+Das {stackstate-product-name} Helm-Chart stellt einen `otel-receiver` Dienst in seinen Werten bereit, wo ein dedizierter `ingress` erstellt werden kann. Dies ist standardmäßig deaktiviert. Der für `otel-receiver` erforderliche Ingress muss das GRPC-Protokoll unterstützen. Beachten Sie, dass die Einrichtung des Controllers selbst und der Zertifikate über den Rahmen dieses Dokuments hinausgeht.
 
-Erstellen Sie eine Datei `ingress_otel_values.yaml` mit folgendem Inhalt, um den `opentelemetry-collector` Ingress für {stackstate-product-name} zu konfigurieren. Ersetzen Sie `MY_DOMAIN` durch Ihre eigene Domain (die mit Ihrem Ingress-Controller verknüpft ist) und setzen Sie den richtigen Namen für die `otlp-tls-secret`. Konsultieren Sie die Dokumentation Ihres Ingress-Controllers für die richtigen Anmerkungen, die gesetzt werden müssen. Alle untenstehenden Felder sind optional, zum Beispiel, wenn kein TLS verwendet wird, lassen Sie diesen Abschnitt weg, aber beachten Sie, dass {stackstate-product-name} auch den Verkehr nicht verschlüsselt.
+Erstellen Sie eine Datei `ingress_otel_values.yaml` mit folgendem Inhalt, um den `otel-receiver` Ingress für {stackstate-product-name} zu konfigurieren. Ersetzen Sie `MY_DOMAIN` durch Ihre eigene Domain (die mit Ihrem Ingress-Controller verknüpft ist) und setzen Sie den richtigen Namen für die `otlp-tls-secret`. Konsultieren Sie die Dokumentation Ihres Ingress-Controllers für die richtigen Anmerkungen, die gesetzt werden müssen. Alle untenstehenden Felder sind optional, zum Beispiel, wenn kein TLS verwendet wird, lassen Sie diesen Abschnitt weg, aber beachten Sie, dass {stackstate-product-name} auch den Verkehr nicht verschlüsselt.
 
 [tabs]
 ====
@@ -120,12 +120,12 @@ Stellen Sie sicher, dass Sie Traefik < 3.6.3 or >= 3.6.7 (mit Helm-Chart-Version
 =====
 Das Exponieren des OpenTelemetry Collector GRPC-Endpunkts über Traefik wird ab der {stackstate-product-name} Helm-Chart-Version v2.8.0 unterstützt.
 
-Beachten Sie, dass der GRPC-Hosteintrag eine explizite `serviceName: suse-observability-otel-collector-grpc` erfordert, um den Verkehr zum richtigen Backend-Dienst zu leiten.
+Beachten Sie, dass der GRPC-Hosteintrag eine explizite `serviceName: suse-observability-otel-receiver-grpc` erfordert, um den Verkehr zum richtigen Backend-Dienst zu leiten.
 =====
 
 [,text]
 ----
-opentelemetry-collector:
+otel-receiver:
   ingress:
     enabled: true
     ingressClassName: traefik
@@ -136,7 +136,7 @@ opentelemetry-collector:
         paths:
           - path: /
             pathType: Prefix
-            serviceName: suse-observability-otel-collector-grpc
+            serviceName: suse-observability-otel-receiver-grpc
             port: 4317
     tls:
       - hosts:
@@ -170,7 +170,7 @@ Das Ingress Nginx-Projekt wird https://kubernetes.io/blog/2025/11/11/ingress-ngi
 
 [,text]
 ----
-opentelemetry-collector:
+otel-receiver:
   ingress:
     enabled: true
     ingressClassName: nginx

--- a/docs/latest/modules/de/pages/setup/otel/otlp-apis.adoc
+++ b/docs/latest/modules/de/pages/setup/otel/otlp-apis.adoc
@@ -19,7 +19,7 @@ Für eine selbstgehostete Installation müssen Sie einen der Endpunkte oder beid
 
 Wenn SUSE Observability im selben Cluster wie der Collector läuft, können Sie es auch ohne Ingress verwenden, indem Sie die Service-Endpunkte nutzen. Dies ist jedoch nur möglich, wenn das HTTP-Protokoll verwendet wird:
 
-* OTLP über HTTP: `http://suse-observability-otel-collector.<namespace>.svc.cluster.local:4318`
+* OTLP über HTTP: `http://suse-observability-otel-receiver.<namespace>.svc.cluster.local:4318`
 
 Stellen Sie sicher, dass Sie `insecure: true` in der Collector-Konfiguration (siehe nächster Abschnitt) festlegen, um die Verwendung von einfachen HTTP-Endpunkten anstelle von HTTPS zu ermöglichen. 
 

--- a/docs/latest/modules/de/pages/use/security/self-signed-certificates.adoc
+++ b/docs/latest/modules/de/pages/use/security/self-signed-certificates.adoc
@@ -67,7 +67,7 @@ ingress:
         - suse-observability.MY_DOMAIN
       secretName: tls-secret
 
-opentelemetry-collector:
+otel-receiver:
   ingress:
     enabled: true
     ingressClassName: traefik
@@ -123,7 +123,7 @@ ingress:
         - suse-observability.MY_DOMAIN
       secretName: tls-secret
 
-opentelemetry-collector:
+otel-receiver:
   ingress:
     enabled: true
     ingressClassName: nginx

--- a/docs/latest/modules/en/pages/setup/install-stackstate/advanced-troubleshooting.adoc
+++ b/docs/latest/modules/en/pages/setup/install-stackstate/advanced-troubleshooting.adoc
@@ -62,8 +62,8 @@ SUSE Observability platform gets data pushed by the agent and OpenTelemetry (OTE
   *** `<release-name>-suse-observability-receiver-base`-*: All other SUSE Observability Agent data comes through here.
  ** `Receiver-NonSplit`:
   *** `<release-name>-suse-observability-receiver-*`: All SUSE Observability Agent data comes through here.
-* `OpenTelemetry Collector`: Provides an endpoint OpenTelemetry agents can push OpenTelemetry data to and produces traces, metrics and topology based on the pushed data.
- ** `suse-observability-otel-collector-0`: Single pod implementing the OTEL collector
+* `OTLP Receiver`: Provides an endpoint OpenTelemetry agents can push OpenTelemetry data to and produces traces, metrics and topology based on the pushed data.
+ ** `suse-observability-otel-receiver-0`: Single pod implementing the OTLP receiver
 
 === Processing and serving
 

--- a/docs/latest/modules/en/pages/setup/install-stackstate/kubernetes_openshift/ingress.adoc
+++ b/docs/latest/modules/en/pages/setup/install-stackstate/kubernetes_openshift/ingress.adoc
@@ -187,9 +187,9 @@ This step assumes that xref:/setup/install-stackstate/kubernetes_openshift/kuber
 
 == Configure Ingress Rule for Open Telemetry
 
-The {stackstate-product-name} Helm chart exposes an `opentelemetry-collector` service in its values where a dedicated `ingress` can be created. This is disabled by default. The ingress needed for `opentelemetry-collector` purposes needs to support GRPC protocol. Note that setting up the controller itself and the certificates is beyond the scope of this document.
+The {stackstate-product-name} Helm chart exposes an `otel-receiver` service in its values where a dedicated `ingress` can be created. This is disabled by default. The ingress needed for `otel-receiver` purposes needs to support GRPC protocol. Note that setting up the controller itself and the certificates is beyond the scope of this document.
 
-To configure the `opentelemetry-collector` ingress for {stackstate-product-name}, create a file `ingress_otel_values.yaml` with contents like below. Replace `MY_DOMAIN` with your own domain (that's linked with your ingress controller) and set the correct name for the `otlp-tls-secret`. Consult the documentation of your ingress controller for the correct annotations to set. All fields below are optional, for example, if no TLS will be used, omit that section but be aware that {stackstate-product-name} also doesn't encrypt the traffic.
+To configure the `otel-receiver` ingress for {stackstate-product-name}, create a file `ingress_otel_values.yaml` with contents like below. Replace `MY_DOMAIN` with your own domain (that's linked with your ingress controller) and set the correct name for the `otlp-tls-secret`. Consult the documentation of your ingress controller for the correct annotations to set. All fields below are optional, for example, if no TLS will be used, omit that section but be aware that {stackstate-product-name} also doesn't encrypt the traffic.
 
 [tabs]
 ====
@@ -206,12 +206,12 @@ Make sure to use Traefik < 3.6.3 or >= 3.6.7 (with Helm chart version >= 39.0.0)
 =====
 Exposing the OpenTelemetry Collector GRPC endpoint via Traefik is supported starting with {stackstate-product-name} Helm chart version v2.8.0.
 
-Note that the GRPC host entry requires an explicit `serviceName: suse-observability-otel-collector-grpc` to route traffic to the correct backend service.
+Note that the GRPC host entry requires an explicit `serviceName: suse-observability-otel-receiver-grpc` to route traffic to the correct backend service.
 =====
 
 [,text]
 ----
-opentelemetry-collector:
+otel-receiver:
   ingress:
     enabled: true
     ingressClassName: traefik
@@ -222,7 +222,7 @@ opentelemetry-collector:
         paths:
           - path: /
             pathType: Prefix
-            serviceName: suse-observability-otel-collector-grpc
+            serviceName: suse-observability-otel-receiver-grpc
             port: 4317
     tls:
       - hosts:
@@ -256,7 +256,7 @@ The Ingress Nginx project is https://kubernetes.io/blog/2025/11/11/ingress-nginx
 
 [,text]
 ----
-opentelemetry-collector:
+otel-receiver:
   ingress:
     enabled: true
     ingressClassName: nginx
@@ -335,7 +335,7 @@ gRPC only::
 --
 [,text]
 ----
-opentelemetry-collector:
+otel-receiver:
   gateway:
     enabled: true
     kind: GRPCRoute
@@ -354,7 +354,7 @@ HTTP and gRPC::
 --
 [,text]
 ----
-opentelemetry-collector:
+otel-receiver:
   gateway:
     enabled: true
     kind: HTTPRoute

--- a/docs/latest/modules/en/pages/setup/otel/otlp-apis.adoc
+++ b/docs/latest/modules/en/pages/setup/otel/otlp-apis.adoc
@@ -19,7 +19,7 @@ For a self-hosted installation you need to enable one of the endpoints, or both,
 
 When SUSE Observability is running in the same cluster as the collector you can also use it without ingress by using the service endpoints, however this is only possible using the HTTP protocol:
 
-* OTLP over HTTP: `+http://suse-observability-otel-collector.<namespace>.svc.cluster.local:4318+`
+* OTLP over HTTP: `+http://suse-observability-otel-receiver.<namespace>.svc.cluster.local:4318+`
 
 Make sure to set `insecure: true` in the collector configuration (see next section) to allow the usage of plain http endpoints instead of https. 
 

--- a/docs/latest/modules/en/pages/setup/otel/otlp-apis.adoc
+++ b/docs/latest/modules/en/pages/setup/otel/otlp-apis.adoc
@@ -15,6 +15,13 @@ The endpoints for SUSE Cloud Observability are:
 
 == Self-hosted SUSE Observability
 
+[NOTE]
+====
+A self-hosted installation contains a component named `otel-receiver`. This is the fixed OTLP ingest endpoint of the SUSE Observability platform itself, and it is not the collector you deploy for your own applications. You do not configure pipelines, receivers or exporters on it.
+
+The collector described on this page is a separate deployment that you own and configure, and that sends its data to SUSE Observability. See xref:/setup/otel/collector.adoc[the collector documentation] for that.
+====
+
 For a self-hosted installation you need to enable one of the endpoints, or both, by configuring the ingress for SUSE Observability as xref:/setup/install-stackstate/kubernetes_openshift/ingress.adoc#_configure_ingress_rule_for_open_telemetry[described here].
 
 When SUSE Observability is running in the same cluster as the collector you can also use it without ingress by using the service endpoints, however this is only possible using the HTTP protocol:

--- a/docs/latest/modules/en/pages/setup/upgrade-stackstate/version-specific-upgrade-instructions.adoc
+++ b/docs/latest/modules/en/pages/setup/upgrade-stackstate/version-specific-upgrade-instructions.adoc
@@ -17,6 +17,19 @@ This page provides specific instructions and details of any required manual step
 
 == Upgrade instructions
 
+=== 2.10.4
+
+* The `opentelemetry-collector` Helm values key has been renamed to `otel-receiver`, to make clear that it configures a fixed part of the {stackstate-product-name} platform rather than a general-purpose OpenTelemetry Collector. Rename this block in your `values.yaml`; leaving the old key in place will cause the deployment to **fail**, because Helm would otherwise silently ignore everything under it.
++
+[,yaml]
+----
+otel-receiver:
+  resources:
+    limits:
+      memory: 512Mi
+----
+* The Kubernetes resources of this component are renamed from `suse-observability-otel-collector` to `suse-observability-otel-receiver`, and its `app.kubernetes.io/name` label changes from `opentelemetry-collector` to `otel-receiver`. Update anything that selects on the old names, such as your own `NetworkPolicy`, `ServiceMonitor` or `PrometheusRule` resources, dashboards, and scripts that reference the pod or StatefulSet by name. The OTLP endpoints exposed through the ingress are unchanged.
+
 === 2.10.0
 
 * The Helm chart `values.yaml` has undergone a major refactoring to improve readability and maintainability, you must review the xref:setup/upgrade-stackstate/v2.10.0-helm.adoc[Helm chart migration guide for v2.10.0] and update your `values.yaml` accordingly.

--- a/docs/latest/modules/en/pages/use/security/self-signed-certificates.adoc
+++ b/docs/latest/modules/en/pages/use/security/self-signed-certificates.adoc
@@ -67,7 +67,7 @@ ingress:
         - suse-observability.MY_DOMAIN
       secretName: tls-secret
 
-opentelemetry-collector:
+otel-receiver:
   ingress:
     enabled: true
     ingressClassName: traefik
@@ -123,7 +123,7 @@ ingress:
         - suse-observability.MY_DOMAIN
       secretName: tls-secret
 
-opentelemetry-collector:
+otel-receiver:
   ingress:
     enabled: true
     ingressClassName: nginx

--- a/docs/latest/modules/es/pages/setup/install-stackstate/advanced-troubleshooting.adoc
+++ b/docs/latest/modules/es/pages/setup/install-stackstate/advanced-troubleshooting.adoc
@@ -63,7 +63,7 @@ La plataforma de observabilidad de SUSE recibe datos enviados por el agente y el
  ** `Receiver-NonSplit`:
   *** `<release-name>-suse-observability-receiver-*`: Todos los datos del agente de observabilidad de SUSE pasan por aquí.
 * `OpenTelemetry Collector`: Proporciona un punto final al que los agentes de OpenTelemetry pueden enviar datos de OpenTelemetry y produce trazas, métricas y topología basadas en los datos enviados.
- ** `suse-observability-otel-collector-0`: Pod único que implementa el colector OTEL
+ ** `suse-observability-otel-receiver-0`: Pod único que implementa el colector OTEL
 
 === Procesamiento y servicio
 

--- a/docs/latest/modules/es/pages/setup/install-stackstate/kubernetes_openshift/ingress.adoc
+++ b/docs/latest/modules/es/pages/setup/install-stackstate/kubernetes_openshift/ingress.adoc
@@ -101,9 +101,9 @@ Este paso asume que ya se ha ejecutado xref:/setup/install-stackstate/kubernetes
 
 == Configurar la regla de Ingress para Open Telemetry
 
-El {stackstate-product-name} gráfico de Helm expone un servicio `opentelemetry-collector` en sus valores donde se puede crear un `ingress` dedicado. Esto está inhabilitado por defecto. El Ingress necesario para fines de `opentelemetry-collector` debe soportar el protocolo GRPC. Tenga en cuenta que la configuración del controlador en sí y los certificados está más allá del alcance de este documento.
+El {stackstate-product-name} gráfico de Helm expone un servicio `otel-receiver` en sus valores donde se puede crear un `ingress` dedicado. Esto está inhabilitado por defecto. El Ingress necesario para fines de `otel-receiver` debe soportar el protocolo GRPC. Tenga en cuenta que la configuración del controlador en sí y los certificados está más allá del alcance de este documento.
 
-Para configurar el `opentelemetry-collector` Ingress para {stackstate-product-name}, cree un archivo `ingress_otel_values.yaml` con contenidos como los siguientes. Reemplace `MY_DOMAIN` con su propio dominio (que esté vinculado con su controlador de Ingress) y establezca el nombre correcto para el `otlp-tls-secret`. Consulte la documentación de su controlador de Ingress para las anotaciones correctas que debe establecer. Todos los campos a continuación son opcionales, por ejemplo, si no se utilizará TLS, omita esa sección, pero tenga en cuenta que {stackstate-product-name} tampoco cifra el tráfico.
+Para configurar el `otel-receiver` Ingress para {stackstate-product-name}, cree un archivo `ingress_otel_values.yaml` con contenidos como los siguientes. Reemplace `MY_DOMAIN` con su propio dominio (que esté vinculado con su controlador de Ingress) y establezca el nombre correcto para el `otlp-tls-secret`. Consulte la documentación de su controlador de Ingress para las anotaciones correctas que debe establecer. Todos los campos a continuación son opcionales, por ejemplo, si no se utilizará TLS, omita esa sección, pero tenga en cuenta que {stackstate-product-name} tampoco cifra el tráfico.
 
 [tabs]
 ====
@@ -120,12 +120,12 @@ Asegúrese de utilizar Traefik < 3.6.3 or >= 3.6.7 (con versión del gráfico de
 =====
 Exponer el punto final GRPC del OpenTelemetry Collector a través de Traefik es compatible a partir de la versión v2.8.0 del gráfico Helm {stackstate-product-name}.
 
-Tenga en cuenta que la entrada del host GRPC requiere un `serviceName: suse-observability-otel-collector-grpc` explícito para enrutar el tráfico al servicio backend correcto.
+Tenga en cuenta que la entrada del host GRPC requiere un `serviceName: suse-observability-otel-receiver-grpc` explícito para enrutar el tráfico al servicio backend correcto.
 =====
 
 [,text]
 ----
-opentelemetry-collector:
+otel-receiver:
   ingress:
     enabled: true
     ingressClassName: traefik
@@ -136,7 +136,7 @@ opentelemetry-collector:
         paths:
           - path: /
             pathType: Prefix
-            serviceName: suse-observability-otel-collector-grpc
+            serviceName: suse-observability-otel-receiver-grpc
             port: 4317
     tls:
       - hosts:
@@ -170,7 +170,7 @@ El proyecto Ingress Nginx está https://kubernetes.io/blog/2025/11/11/ingress-ng
 
 [,text]
 ----
-opentelemetry-collector:
+otel-receiver:
   ingress:
     enabled: true
     ingressClassName: nginx

--- a/docs/latest/modules/es/pages/setup/otel/otlp-apis.adoc
+++ b/docs/latest/modules/es/pages/setup/otel/otlp-apis.adoc
@@ -19,7 +19,7 @@ Para una instalación autoalojada necesitas habilitar uno de los puntos finales,
 
 Cuando SUSE Observability se ejecuta en el mismo clúster que el colector, también puedes usarlo sin ingress utilizando los puntos finales del servicio, sin embargo, esto solo es posible utilizando el protocolo HTTP:
 
-* OTLP sobre HTTP: `http://suse-observability-otel-collector.<namespace>.svc.cluster.local:4318`
+* OTLP sobre HTTP: `http://suse-observability-otel-receiver.<namespace>.svc.cluster.local:4318`
 
 Asegúrate de establecer `insecure: true` en la configuración del colector (ver la siguiente sección) para permitir el uso de puntos finales HTTP simples en lugar de https. 
 

--- a/docs/latest/modules/es/pages/use/security/self-signed-certificates.adoc
+++ b/docs/latest/modules/es/pages/use/security/self-signed-certificates.adoc
@@ -67,7 +67,7 @@ ingress:
         - suse-observability.MY_DOMAIN
       secretName: tls-secret
 
-opentelemetry-collector:
+otel-receiver:
   ingress:
     enabled: true
     ingressClassName: traefik
@@ -123,7 +123,7 @@ ingress:
         - suse-observability.MY_DOMAIN
       secretName: tls-secret
 
-opentelemetry-collector:
+otel-receiver:
   ingress:
     enabled: true
     ingressClassName: nginx

--- a/docs/latest/modules/fr/pages/setup/install-stackstate/advanced-troubleshooting.adoc
+++ b/docs/latest/modules/fr/pages/setup/install-stackstate/advanced-troubleshooting.adoc
@@ -63,7 +63,7 @@ La plateforme d'observabilité SUSE reçoit des données envoyées par l'agent e
  ** `Receiver-NonSplit` :
   *** `<release-name>-suse-observability-receiver-*` : Toutes les données de l'agent d'observabilité SUSE passent par ici.
 * `OpenTelemetry Collector` : Fournit un point de terminaison auquel les agents OpenTelemetry peuvent envoyer des données OpenTelemetry et produit des traces, des métriques et une topologie basées sur les données envoyées.
- ** `suse-observability-otel-collector-0` : Pod unique implémentant le collecteur OTEL
+ ** `suse-observability-otel-receiver-0` : Pod unique implémentant le collecteur OTEL
 
 === Traitement et service
 

--- a/docs/latest/modules/fr/pages/setup/install-stackstate/kubernetes_openshift/ingress.adoc
+++ b/docs/latest/modules/fr/pages/setup/install-stackstate/kubernetes_openshift/ingress.adoc
@@ -101,9 +101,9 @@ Cette étape suppose que xref:/setup/install-stackstate/kubernetes_openshift/kub
 
 == Configurer la règle Ingress pour Open Telemetry
 
-Le {stackstate-product-name} chart Helm expose un service `opentelemetry-collector` dans ses valeurs dans lequel un `ingress` dédié peut être créé. Ceci est désactivé par défaut. L'Ingress nécessaire pour des fins `opentelemetry-collector` doit prendre en charge le protocole GRPC. Notez que la configuration du contrôleur lui-même et des certificats dépasse le cadre de ce document.
+Le {stackstate-product-name} chart Helm expose un service `otel-receiver` dans ses valeurs dans lequel un `ingress` dédié peut être créé. Ceci est désactivé par défaut. L'Ingress nécessaire pour des fins `otel-receiver` doit prendre en charge le protocole GRPC. Notez que la configuration du contrôleur lui-même et des certificats dépasse le cadre de ce document.
 
-Pour configurer l'Ingress `opentelemetry-collector` pour {stackstate-product-name}, créez un fichier `ingress_otel_values.yaml` avec un contenu comme ci-dessous. Remplacez `MY_DOMAIN` par votre propre domaine (qui est lié à votre contrôleur Ingress) et définissez le nom correct pour le `otlp-tls-secret`. Consultez la documentation de votre contrôleur d'ingress pour les annotations correctes à définir. Tous les champs ci-dessous sont optionnels, par exemple, si aucun TLS n'est utilisé, omettez cette section mais sachez que {stackstate-product-name} ne chiffre pas le trafic.
+Pour configurer l'Ingress `otel-receiver` pour {stackstate-product-name}, créez un fichier `ingress_otel_values.yaml` avec un contenu comme ci-dessous. Remplacez `MY_DOMAIN` par votre propre domaine (qui est lié à votre contrôleur Ingress) et définissez le nom correct pour le `otlp-tls-secret`. Consultez la documentation de votre contrôleur d'ingress pour les annotations correctes à définir. Tous les champs ci-dessous sont optionnels, par exemple, si aucun TLS n'est utilisé, omettez cette section mais sachez que {stackstate-product-name} ne chiffre pas le trafic.
 
 [tabs]
 ====
@@ -120,12 +120,12 @@ Assurez-vous d'utiliser Traefik < 3.6.3 or >= 3.6.7 (avec la version du chart He
 =====
 L'exposition du point de terminaison GRPC du Collecteur OpenTelemetry via Traefik est prise en charge à partir de la version v2.8.0 du {stackstate-product-name} chart Helm.
 
-Notez que l'entrée hôte GRPC nécessite un `serviceName: suse-observability-otel-collector-grpc` explicite pour acheminer le trafic vers le service backend correct.
+Notez que l'entrée hôte GRPC nécessite un `serviceName: suse-observability-otel-receiver-grpc` explicite pour acheminer le trafic vers le service backend correct.
 =====
 
 [,text]
 ----
-opentelemetry-collector:
+otel-receiver:
   ingress:
     enabled: true
     ingressClassName: traefik
@@ -136,7 +136,7 @@ opentelemetry-collector:
         paths:
           - path: /
             pathType: Prefix
-            serviceName: suse-observability-otel-collector-grpc
+            serviceName: suse-observability-otel-receiver-grpc
             port: 4317
     tls:
       - hosts:
@@ -170,7 +170,7 @@ Le projet Ingress Nginx est https://kubernetes.io/blog/2025/11/11/ingress-nginx-
 
 [,text]
 ----
-opentelemetry-collector:
+otel-receiver:
   ingress:
     enabled: true
     ingressClassName: nginx

--- a/docs/latest/modules/fr/pages/setup/otel/otlp-apis.adoc
+++ b/docs/latest/modules/fr/pages/setup/otel/otlp-apis.adoc
@@ -19,7 +19,7 @@ Pour une installation auto-hébergée, vous devez activer l'un des points de ter
 
 Lorsque SUSE Observability fonctionne dans le même cluster que le collecteur, vous pouvez également l'utiliser sans ingress en utilisant les points de terminaison de service, cependant cela n'est possible qu'en utilisant le protocole HTTP :
 
-* OTLP sur HTTP : `http://suse-observability-otel-collector.<namespace>.svc.cluster.local:4318`
+* OTLP sur HTTP : `http://suse-observability-otel-receiver.<namespace>.svc.cluster.local:4318`
 
 Assurez-vous de définir `insecure: true` dans la configuration du collecteur (voir la section suivante) pour permettre l'utilisation de points de terminaison HTTP simples au lieu de HTTPS. 
 

--- a/docs/latest/modules/fr/pages/use/security/self-signed-certificates.adoc
+++ b/docs/latest/modules/fr/pages/use/security/self-signed-certificates.adoc
@@ -67,7 +67,7 @@ ingress:
         - suse-observability.MY_DOMAIN
       secretName: tls-secret
 
-opentelemetry-collector:
+otel-receiver:
   ingress:
     enabled: true
     ingressClassName: traefik
@@ -123,7 +123,7 @@ ingress:
         - suse-observability.MY_DOMAIN
       secretName: tls-secret
 
-opentelemetry-collector:
+otel-receiver:
   ingress:
     enabled: true
     ingressClassName: nginx

--- a/docs/latest/modules/ja/pages/setup/install-stackstate/advanced-troubleshooting.adoc
+++ b/docs/latest/modules/ja/pages/setup/install-stackstate/advanced-troubleshooting.adoc
@@ -63,7 +63,7 @@ SUSE Observabilityプラットフォームは、エージェントとOpenTelemet
  ** `Receiver-NonSplit`:
   *** `<release-name>-suse-observability-receiver-*`:すべてのSUSE Observability Agentデータはここを通過します。
 * `OpenTelemetry Collector`:OpenTelemetryエージェントがOpenTelemetryデータをプッシュできるエンドポイントを提供し、プッシュされたデータに基づいてトレース、メトリクス、トポロジーを生成します。
- ** `suse-observability-otel-collector-0`:OTELコレクターを実装する単一のポッド
+ ** `suse-observability-otel-receiver-0`:OTELコレクターを実装する単一のポッド
 
 === 処理と提供
 

--- a/docs/latest/modules/ja/pages/setup/install-stackstate/kubernetes_openshift/ingress.adoc
+++ b/docs/latest/modules/ja/pages/setup/install-stackstate/kubernetes_openshift/ingress.adoc
@@ -101,9 +101,9 @@ suse-observability/suse-observability
 
 == オープンテレメトリのためのイングレスルールを構成します。
 
-{stackstate-product-name} Helmチャートは、その値の中で`opentelemetry-collector`サービスを公開し、専用の`ingress`を作成できます。これはデフォルトでは無効になっています。`opentelemetry-collector`目的に必要なイングレスは、GRPCプロトコルをサポートする必要があります。コントローラー自体と証明書の設定は、この文書の範囲を超えていることに注意してください。
+{stackstate-product-name} Helmチャートは、その値の中で`otel-receiver`サービスを公開し、専用の`ingress`を作成できます。これはデフォルトでは無効になっています。`otel-receiver`目的に必要なイングレスは、GRPCプロトコルをサポートする必要があります。コントローラー自体と証明書の設定は、この文書の範囲を超えていることに注意してください。
 
-{stackstate-product-name}のために`opentelemetry-collector`イングレスを構成するには、以下のような内容のファイル`ingress_otel_values.yaml`を作成してください。`MY_DOMAIN`を自分のドメイン（イングレスコントローラーにリンクされている）に置き換え、`otlp-tls-secret`の正しい名前を設定してください。正しいアノテーションを設定するために、Ingressコントローラーのドキュメントを参照してください。以下のすべてのフィールドはオプションです。たとえば、TLSを使用しない場合はそのセクションを省略できますが、{stackstate-product-name}もトラフィックを暗号化しないことに注意してください。
+{stackstate-product-name}のために`otel-receiver`イングレスを構成するには、以下のような内容のファイル`ingress_otel_values.yaml`を作成してください。`MY_DOMAIN`を自分のドメイン（イングレスコントローラーにリンクされている）に置き換え、`otlp-tls-secret`の正しい名前を設定してください。正しいアノテーションを設定するために、Ingressコントローラーのドキュメントを参照してください。以下のすべてのフィールドはオプションです。たとえば、TLSを使用しない場合はそのセクションを省略できますが、{stackstate-product-name}もトラフィックを暗号化しないことに注意してください。
 
 [tabs]
 ====
@@ -120,12 +120,12 @@ Traefik < 3.6.3 or >= 3.6.7（Helmチャートバージョン>= 39.0.0）を使�
 =====
 OpenTelemetry Collector GRPCエンドポイントをTraefik経由で公開することは、{stackstate-product-name} Helmチャートバージョンv2.8.0以降でサポートされています。
 
-GRPCホストエントリは、トラフィックを正しいバックエンドサービスにルーティングするために明示的な`serviceName: suse-observability-otel-collector-grpc`を必要とすることに注意してください。
+GRPCホストエントリは、トラフィックを正しいバックエンドサービスにルーティングするために明示的な`serviceName: suse-observability-otel-receiver-grpc`を必要とすることに注意してください。
 =====
 
 [,text]
 ----
-opentelemetry-collector:
+otel-receiver:
   ingress:
     enabled: true
     ingressClassName: traefik
@@ -136,7 +136,7 @@ opentelemetry-collector:
         paths:
           - path: /
             pathType: Prefix
-            serviceName: suse-observability-otel-collector-grpc
+            serviceName: suse-observability-otel-receiver-grpc
             port: 4317
     tls:
       - hosts:
@@ -170,7 +170,7 @@ Ingress Nginxプロジェクトはhttps://kubernetes.io/blog/2025/11/11/ingress-
 
 [,text]
 ----
-opentelemetry-collector:
+otel-receiver:
   ingress:
     enabled: true
     ingressClassName: nginx

--- a/docs/latest/modules/ja/pages/setup/otel/otlp-apis.adoc
+++ b/docs/latest/modules/ja/pages/setup/otel/otlp-apis.adoc
@@ -19,7 +19,7 @@ SUSE Cloud Observability のエンドポイントは次のとおりです：
 
 SUSE Observability がコレクターと同じクラスターで実行されている場合、サービスエンドポイントを使用してイングレスなしで使用することもできますが、これは HTTP プロトコルを使用する場合のみ可能です：
 
-* OTLP over HTTP: `http://suse-observability-otel-collector.<namespace>.svc.cluster.local:4318`
+* OTLP over HTTP: `http://suse-observability-otel-receiver.<namespace>.svc.cluster.local:4318`
 
 コレクターの設定で `insecure: true` を設定して、https の代わりにプレーンな http エンドポイントを使用できるようにしてください（次のセクションを参照）。
 

--- a/docs/latest/modules/ja/pages/use/security/self-signed-certificates.adoc
+++ b/docs/latest/modules/ja/pages/use/security/self-signed-certificates.adoc
@@ -67,7 +67,7 @@ ingress:
         - suse-observability.MY_DOMAIN
       secretName: tls-secret
 
-opentelemetry-collector:
+otel-receiver:
   ingress:
     enabled: true
     ingressClassName: traefik
@@ -123,7 +123,7 @@ ingress:
         - suse-observability.MY_DOMAIN
       secretName: tls-secret
 
-opentelemetry-collector:
+otel-receiver:
   ingress:
     enabled: true
     ingressClassName: nginx

--- a/docs/latest/modules/pt/pages/setup/install-stackstate/advanced-troubleshooting.adoc
+++ b/docs/latest/modules/pt/pages/setup/install-stackstate/advanced-troubleshooting.adoc
@@ -63,7 +63,7 @@ A plataforma de Observabilidade SUSE recebe dados enviados pelo agente e pelo ag
  ** `Receiver-NonSplit`:
   *** `<release-name>-suse-observability-receiver-*`: Todos os dados do Agente de Observabilidade SUSE passam por aqui.
 * `OpenTelemetry Collector`: Fornece um endpoint para que os agentes OpenTelemetry possam enviar dados OpenTelemetry e produz traços, métricas e topologia com base nos dados enviados.
- ** `suse-observability-otel-collector-0`: Pod único implementando o coletor OTEL
+ ** `suse-observability-otel-receiver-0`: Pod único implementando o coletor OTEL
 
 === Processamento e entrega.
 

--- a/docs/latest/modules/pt/pages/setup/install-stackstate/kubernetes_openshift/ingress.adoc
+++ b/docs/latest/modules/pt/pages/setup/install-stackstate/kubernetes_openshift/ingress.adoc
@@ -101,9 +101,9 @@ Esta etapa assume que xref:/setup/install-stackstate/kubernetes_openshift/kubern
 
 == Configurar a Regra de Ingress para Open Telemetry
 
-O {stackstate-product-name} gráfico Helm expõe um serviço `opentelemetry-collector` em seus valores onde um `ingress` dedicado pode ser criado. Isso está desabilitado por padrão. O ingress necessário para fins de `opentelemetry-collector` precisa suportar o protocolo GRPC. Observe que a configuração do controlador em si e dos certificados está além do escopo deste documento.
+O {stackstate-product-name} gráfico Helm expõe um serviço `otel-receiver` em seus valores onde um `ingress` dedicado pode ser criado. Isso está desabilitado por padrão. O ingress necessário para fins de `otel-receiver` precisa suportar o protocolo GRPC. Observe que a configuração do controlador em si e dos certificados está além do escopo deste documento.
 
-Para configurar o `opentelemetry-collector` ingress para {stackstate-product-name}, crie um arquivo `ingress_otel_values.yaml` com o conteúdo conforme abaixo. Substitua `MY_DOMAIN` pelo seu próprio domínio (que está vinculado ao seu controlador de entrada) e defina o nome correto para o `otlp-tls-secret`. Consulte a documentação do seu controlador de entrada para as anotações corretas a serem definidas. Todos os campos abaixo são opcionais, por exemplo, se nenhum TLS for usado, omita essa seção, mas esteja ciente de que {stackstate-product-name} também não criptografa o tráfego.
+Para configurar o `otel-receiver` ingress para {stackstate-product-name}, crie um arquivo `ingress_otel_values.yaml` com o conteúdo conforme abaixo. Substitua `MY_DOMAIN` pelo seu próprio domínio (que está vinculado ao seu controlador de entrada) e defina o nome correto para o `otlp-tls-secret`. Consulte a documentação do seu controlador de entrada para as anotações corretas a serem definidas. Todos os campos abaixo são opcionais, por exemplo, se nenhum TLS for usado, omita essa seção, mas esteja ciente de que {stackstate-product-name} também não criptografa o tráfego.
 
 [tabs]
 ====
@@ -120,12 +120,12 @@ Certifique-se de usar o Traefik < 3.6.3 or >= 3.6.7 (com versão do gráfico Hel
 =====
 Expor o endpoint GRPC do OpenTelemetry Collector via Traefik é suportado a partir da versão v2.8.0 do {stackstate-product-name} gráfico Helm.
 
-Observe que a entrada do host GRPC requer um `serviceName: suse-observability-otel-collector-grpc` explícito para rotear o tráfego para o serviço de backend correto.
+Observe que a entrada do host GRPC requer um `serviceName: suse-observability-otel-receiver-grpc` explícito para rotear o tráfego para o serviço de backend correto.
 =====
 
 [,text]
 ----
-opentelemetry-collector:
+otel-receiver:
   ingress:
     enabled: true
     ingressClassName: traefik
@@ -136,7 +136,7 @@ opentelemetry-collector:
         paths:
           - path: /
             pathType: Prefix
-            serviceName: suse-observability-otel-collector-grpc
+            serviceName: suse-observability-otel-receiver-grpc
             port: 4317
     tls:
       - hosts:
@@ -170,7 +170,7 @@ O projeto Ingress Nginx está https://kubernetes.io/blog/2025/11/11/ingress-ngin
 
 [,text]
 ----
-opentelemetry-collector:
+otel-receiver:
   ingress:
     enabled: true
     ingressClassName: nginx

--- a/docs/latest/modules/pt/pages/setup/otel/otlp-apis.adoc
+++ b/docs/latest/modules/pt/pages/setup/otel/otlp-apis.adoc
@@ -19,7 +19,7 @@ Para uma instalação auto-hospedada, você precisa habilitar um dos endpoints, 
 
 Quando o SUSE Observability está rodando no mesmo cluster que o coletor, você também pode usá-lo sem ingresso, utilizando os endpoints de serviço, no entanto, isso só é possível usando o protocolo HTTP:
 
-* OTLP sobre HTTP: `http://suse-observability-otel-collector.<namespace>.svc.cluster.local:4318`
+* OTLP sobre HTTP: `http://suse-observability-otel-receiver.<namespace>.svc.cluster.local:4318`
 
 Certifique-se de definir `insecure: true` na configuração do coletor (veja a próxima seção) para permitir o uso de endpoints http simples em vez de https. 
 

--- a/docs/latest/modules/pt/pages/use/security/self-signed-certificates.adoc
+++ b/docs/latest/modules/pt/pages/use/security/self-signed-certificates.adoc
@@ -67,7 +67,7 @@ ingress:
         - suse-observability.MY_DOMAIN
       secretName: tls-secret
 
-opentelemetry-collector:
+otel-receiver:
   ingress:
     enabled: true
     ingressClassName: traefik
@@ -123,7 +123,7 @@ ingress:
         - suse-observability.MY_DOMAIN
       secretName: tls-secret
 
-opentelemetry-collector:
+otel-receiver:
   ingress:
     enabled: true
     ingressClassName: nginx

--- a/docs/latest/modules/zh/pages/setup/install-stackstate/advanced-troubleshooting.adoc
+++ b/docs/latest/modules/zh/pages/setup/install-stackstate/advanced-troubleshooting.adoc
@@ -63,7 +63,7 @@ SUSE Observability 平台通过代理和 OpenTelemetry (OTEL) 代理获取推送
  ** `Receiver-NonSplit`：
   *** `<release-name>-suse-observability-receiver-*`：所有 SUSE Observability 代理数据通过这里传输。
 * `OpenTelemetry Collector`：提供一个端点，OpenTelemetry 代理可以将 OpenTelemetry 数据推送到此端点，并根据推送的数据生成跟踪、指标和拓扑。
- ** `suse-observability-otel-collector-0`：单个 pod 实现 OTEL 收集器
+ ** `suse-observability-otel-receiver-0`：单个 pod 实现 OTEL 收集器
 
 === 处理和服务
 

--- a/docs/latest/modules/zh/pages/setup/install-stackstate/kubernetes_openshift/ingress.adoc
+++ b/docs/latest/modules/zh/pages/setup/install-stackstate/kubernetes_openshift/ingress.adoc
@@ -101,9 +101,9 @@ suse-observability/suse-observability
 
 == 为开放遥测配置入口规则
 
-{stackstate-product-name} Helm 图表在其值中公开了一个 `opentelemetry-collector` 服务，可以创建一个专用的 `ingress`。默认情况下，这处于禁用状态。用于 `opentelemetry-collector` 目的的入口需要支持 GRPC 协议。请注意，设置控制器本身和证书超出了本文件的范围。
+{stackstate-product-name} Helm 图表在其值中公开了一个 `otel-receiver` 服务，可以创建一个专用的 `ingress`。默认情况下，这处于禁用状态。用于 `otel-receiver` 目的的入口需要支持 GRPC 协议。请注意，设置控制器本身和证书超出了本文件的范围。
 
-要为 {stackstate-product-name} 配置 `opentelemetry-collector` 入口，请创建一个文件 `ingress_otel_values.yaml`，内容如下。将 `MY_DOMAIN` 替换为您自己的域名（与您的入口控制器关联）并为 `otlp-tls-secret` 设置正确的名称。请查阅您的入口控制器的文档以获取正确的注释设置。以下所有字段都是可选的，例如，如果不使用 TLS，请省略该部分，但请注意 {stackstate-product-name} 也不会加密流量。
+要为 {stackstate-product-name} 配置 `otel-receiver` 入口，请创建一个文件 `ingress_otel_values.yaml`，内容如下。将 `MY_DOMAIN` 替换为您自己的域名（与您的入口控制器关联）并为 `otlp-tls-secret` 设置正确的名称。请查阅您的入口控制器的文档以获取正确的注释设置。以下所有字段都是可选的，例如，如果不使用 TLS，请省略该部分，但请注意 {stackstate-product-name} 也不会加密流量。
 
 [tabs]
 ====
@@ -120,12 +120,12 @@ Traefik::
 =====
 通过 Traefik 暴露 OpenTelemetry Collector GRPC 端点从 {stackstate-product-name} Helm 图表版本 v2.8.0 开始得到支持。
 
-请注意，GRPC 主机条目需要一个明确的 `serviceName: suse-observability-otel-collector-grpc` 来将流量路由到正确的后端服务。
+请注意，GRPC 主机条目需要一个明确的 `serviceName: suse-observability-otel-receiver-grpc` 来将流量路由到正确的后端服务。
 =====
 
 [,text]
 ----
-opentelemetry-collector:
+otel-receiver:
   ingress:
     enabled: true
     ingressClassName: traefik
@@ -136,7 +136,7 @@ opentelemetry-collector:
         paths:
           - path: /
             pathType: Prefix
-            serviceName: suse-observability-otel-collector-grpc
+            serviceName: suse-observability-otel-receiver-grpc
             port: 4317
     tls:
       - hosts:
@@ -170,7 +170,7 @@ Ingress Nginx 项目正在 https://kubernetes.io/blog/2025/11/11/ingress-nginx-r
 
 [,text]
 ----
-opentelemetry-collector:
+otel-receiver:
   ingress:
     enabled: true
     ingressClassName: nginx

--- a/docs/latest/modules/zh/pages/setup/otel/otlp-apis.adoc
+++ b/docs/latest/modules/zh/pages/setup/otel/otlp-apis.adoc
@@ -19,7 +19,7 @@ SUSE Cloud Observability 的端点为：
 
 当 SUSE Observability 与收集器运行在同一集群中时，您也可通过使用服务端点而无需 ingress，但这仅适用于 HTTP 协议。
 
-* OTLP HTTP 协议: `http://suse-observability-otel-collector.<namespace>.svc.cluster.local:4318`
+* OTLP HTTP 协议: `http://suse-observability-otel-receiver.<namespace>.svc.cluster.local:4318`
 
 请确保在收集器配置中设置 `insecure: true`（参见下一部分），以允许使用普通 HTTP 端点而非 HTTPS。
 

--- a/docs/latest/modules/zh/pages/use/security/self-signed-certificates.adoc
+++ b/docs/latest/modules/zh/pages/use/security/self-signed-certificates.adoc
@@ -67,7 +67,7 @@ ingress:
         - suse-observability.MY_DOMAIN
       secretName: tls-secret
 
-opentelemetry-collector:
+otel-receiver:
   ingress:
     enabled: true
     ingressClassName: traefik
@@ -123,7 +123,7 @@ ingress:
         - suse-observability.MY_DOMAIN
       secretName: tls-secret
 
-opentelemetry-collector:
+otel-receiver:
   ingress:
     enabled: true
     ingressClassName: nginx


### PR DESCRIPTION
## Summary

The platform's OTLP ingest component was named after the upstream OpenTelemetry Collector, so readers repeatedly confused it with the collector they deploy for their own applications. The Helm chart renames it to `otel-receiver` (StackVista/helm-charts-internal#156); this updates the docs to match, and states the distinction explicitly.

## What changed

**Renamed references to the platform component:**

- `setup/otel/otlp-apis.adoc` - in-cluster service endpoint is now `suse-observability-otel-receiver`
- `setup/install-stackstate/advanced-troubleshooting.adoc` - pod is `suse-observability-otel-receiver-0`, and the component is listed as `OTLP Receiver` rather than `OpenTelemetry Collector`
- `setup/install-stackstate/kubernetes_openshift/ingress.adoc` - values key and `serviceName` in all ingress and gateway examples
- `use/security/self-signed-certificates.adoc` - values key in both ingress examples

**Added guidance:**

- A `2.10.4` entry in `version-specific-upgrade-instructions.adoc` covering the renamed values key and the renamed Kubernetes resources. It calls out that the old key now causes a hard failure rather than being silently ignored, and that `app.kubernetes.io/name` changes from `opentelemetry-collector` to `otel-receiver`, which user-authored `NetworkPolicy` / `ServiceMonitor` / `PrometheusRule` selectors and dashboards may depend on.
- A note on the OTLP protocol page stating that `otel-receiver` is the platform's own ingest endpoint and not the collector a user deploys, since conflating the two is what prompted the rename.

## Deliberately unchanged

- **All `setup/otel/` pages about deploying your own collector.** The upstream chart, image, repository and SUSE Application Collection references legitimately use the `opentelemetry-collector` name, as does `job_name: opentelemetry-collector` in user collector configs.
- **`v2.10.0-helm.adoc`.** It is a version-pinned migration guide for a release that shipped under the old name; editing it would make it inaccurate.
- **`migrate-from-6.adoc` and `migrate-from-6-new.adoc`.** The `opentelemetry-collector:` block in each edits the legacy StackState 6.x chart's own values, not ours. Worth a second opinion: step 1 of that procedure tells users to copy their ingress config into the SUSE Observability values, where the key would now need to be `otel-receiver:`. The guide never shows that target snippet, so nothing is concretely wrong, but a docs owner may want to add a pointer.
- **Locales other than `en`.** Following the convention in recent commits, which touch `en` only.

## Open question

The upgrade note is filed under `2.10.4`, matching the chart's current `2.10.4-pre` train. If the rename is held for `2.11.0` instead, that heading needs to move.

## Test plan

- [x] `make local` builds cleanly; the only asciidoctor warnings are pre-existing invalid references in the `de` and `es` locales
- [x] Verified in the rendered HTML that the new upgrade entry, its nested YAML block and the admonition all render, and that the `xref` to the collector page resolves
- [ ] Docs review of the wording, and confirmation of the target release version

Relates to [STAC-24731](https://stackstate.atlassian.net/browse/STAC-24731)